### PR TITLE
feat: (W-014) Bug: merge step treats repos with no CI checks as CI failure

### DIFF
--- a/src/merge/github.ts
+++ b/src/merge/github.ts
@@ -75,13 +75,10 @@ export interface PrCheckStatus {
   pending: number;
 }
 
-export function ghPrChecks(repo: string, prNumber: number): PrCheckStatus {
-  const result = gh(["pr", "checks", String(prNumber), "-R", repo, "--json", "name,state,conclusion"]);
-  if (!result.ok) {
-    return { state: "pending", total: 0, passing: 0, failing: 0, pending: 0 };
-  }
-
-  const checks = JSON.parse(result.stdout || "[]") as Array<{ name: string; state: string; conclusion: string }>;
+/** Pure logic: resolve check state from an array of check results */
+export function resolveCheckState(
+  checks: Array<{ name: string; state: string; conclusion: string }>,
+): PrCheckStatus {
   const total = checks.length;
   const passing = checks.filter(c => c.conclusion === "SUCCESS" || c.conclusion === "success").length;
   const failing = checks.filter(c => c.conclusion === "FAILURE" || c.conclusion === "failure").length;
@@ -89,9 +86,19 @@ export function ghPrChecks(repo: string, prNumber: number): PrCheckStatus {
 
   let state: "pending" | "success" | "failure" = "pending";
   if (failing > 0) state = "failure";
-  else if (pending === 0 && total > 0) state = "success";
+  else if (pending === 0) state = "success";
 
   return { state, total, passing, failing, pending };
+}
+
+export function ghPrChecks(repo: string, prNumber: number): PrCheckStatus {
+  const result = gh(["pr", "checks", String(prNumber), "-R", repo, "--json", "name,state,conclusion"]);
+  if (!result.ok) {
+    return { state: "pending", total: 0, passing: 0, failing: 0, pending: 0 };
+  }
+
+  const checks = JSON.parse(result.stdout || "[]") as Array<{ name: string; state: string; conclusion: string }>;
+  return resolveCheckState(checks);
 }
 
 export function ghPrList(repo: string, opts?: { head?: string; state?: string; limit?: number }): GhPr[] {

--- a/tests/merge/github.test.ts
+++ b/tests/merge/github.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from "bun:test";
+import { resolveCheckState } from "../../src/merge/github";
+
+describe("resolveCheckState", () => {
+  test("returns success when total is 0 (no CI checks configured)", () => {
+    const result = resolveCheckState([]);
+    expect(result.state).toBe("success");
+    expect(result.total).toBe(0);
+  });
+
+  test("returns success when all checks pass", () => {
+    const checks = [
+      { name: "build", state: "COMPLETED", conclusion: "SUCCESS" },
+      { name: "lint", state: "COMPLETED", conclusion: "SUCCESS" },
+    ];
+    const result = resolveCheckState(checks);
+    expect(result.state).toBe("success");
+    expect(result.passing).toBe(2);
+    expect(result.total).toBe(2);
+  });
+
+  test("returns failure when any check fails", () => {
+    const checks = [
+      { name: "build", state: "COMPLETED", conclusion: "SUCCESS" },
+      { name: "lint", state: "COMPLETED", conclusion: "FAILURE" },
+    ];
+    const result = resolveCheckState(checks);
+    expect(result.state).toBe("failure");
+    expect(result.failing).toBe(1);
+  });
+
+  test("returns pending when checks are still running", () => {
+    const checks = [
+      { name: "build", state: "COMPLETED", conclusion: "SUCCESS" },
+      { name: "lint", state: "IN_PROGRESS", conclusion: "" },
+    ];
+    const result = resolveCheckState(checks);
+    expect(result.state).toBe("pending");
+    expect(result.pending).toBe(1);
+  });
+});


### PR DESCRIPTION
## Bug: merge step treats repos with no CI checks as CI failure

In src/merge/github.ts, when total===0 (no CI checks), state stays pending causing watchCI() to timeout and report failure. Fix: treat total===0 as success. GitHub issue: bpamiri/grove#2

**Task:** W-014
**Path:** development
**Cost:** $0.00
**Files changed:** 4

### Quality Gates
- commits: passed — 1 commit on branch
- tests: passed — No test command configured — skipped
- diff_size: passed — 64 lines changed

---
*Created by [Grove](https://grove.cloud)*