### PR TITLE
feat: (W-016) Bug: broker re-processes tasks in terminal states...

### DIFF
--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -31,7 +31,7 @@ function buildOrchestratorPrompt(db: Database): string {
   const treeList = trees.map(t => `- ${t.id}: ${t.path}${t.github ? ` (${t.github})` : ""}`).join("\n");
 
   const activeTasks = db.all<{ id: string; title: string; status: string; tree_id: string }>(
-    "SELECT id, title, status, tree_id FROM tasks WHERE status NOT IN ('completed', 'merged', 'failed') ORDER BY created_at DESC LIMIT 20"
+    "SELECT id, title, status, tree_id FROM tasks WHERE status NOT IN ('done', 'completed', 'merged', 'failed') ORDER BY created_at DESC LIMIT 20"
   );
   const taskList = activeTasks.length > 0
     ? activeTasks.map(t => `- ${t.id}: [${t.status}] ${t.title} (${t.tree_id || "no tree"})`).join("\n")
@@ -197,7 +197,7 @@ function rotate(db: Database): void {
 
   // Build a context summary from DB state (not from the orchestrator itself — it may be slow)
   const activeTasks = db.all<{ id: string; title: string; status: string; tree_id: string }>(
-    "SELECT id, title, status, tree_id FROM tasks WHERE status NOT IN ('completed', 'merged', 'failed') ORDER BY created_at DESC LIMIT 30"
+    "SELECT id, title, status, tree_id FROM tasks WHERE status NOT IN ('done', 'completed', 'merged', 'failed') ORDER BY created_at DESC LIMIT 30"
   );
   const recentEvents = db.recentEvents(20);
 

--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -6,6 +6,7 @@ import { parseCost, isAlive } from "./stream-parser";
 import { createWorktree, branchName } from "../shared/worktree";
 import { deploySandbox, triggerPrompt } from "../shared/sandbox";
 import type { Database } from "../broker/db";
+import { isTerminalStatus } from "../shared/types";
 import type { Task, Tree } from "../shared/types";
 
 export interface WorkerHandle {
@@ -23,6 +24,10 @@ const activeWorkers = new Map<string, WorkerHandle>();
 export function spawnWorker(task: Task, tree: Tree, db: Database, logDir: string): WorkerHandle {
   if (activeWorkers.has(task.id)) {
     throw new Error(`Worker already active for task ${task.id}`);
+  }
+
+  if (isTerminalStatus(task.status)) {
+    throw new Error(`Cannot spawn worker for task ${task.id} in terminal state: ${task.status}`);
   }
 
   mkdirSync(logDir, { recursive: true });

--- a/src/broker/pipeline.ts
+++ b/src/broker/pipeline.ts
@@ -22,6 +22,9 @@ export function wirePipeline(db: Database): void {
     const task = db.taskGet(taskId);
     if (!task || !task.tree_id) return;
 
+    // Skip if task has already moved past "done" (e.g., already evaluated or failed)
+    if (task.status !== "done") return;
+
     const tree = db.treeGet(task.tree_id);
     if (!tree) return;
 

--- a/src/broker/server.ts
+++ b/src/broker/server.ts
@@ -5,6 +5,7 @@ import type { Database } from "./db";
 import { bus } from "./event-bus";
 import { configSet, reloadConfig } from "./config";
 import { expandHome } from "../shared/worktree";
+import { isTerminalStatus } from "../shared/types";
 import type { EventBusMap } from "../shared/types";
 
 export interface ServerOptions {
@@ -372,6 +373,9 @@ async function handleApi(
       const taskId = dispatchMatch[1];
       const task = db.taskGet(taskId);
       if (!task) return json({ error: "Task not found" }, 404);
+      if (isTerminalStatus(task.status)) {
+        return json({ error: `Cannot dispatch task in '${task.status}' state` }, 409);
+      }
       db.taskSetStatus(taskId, "ready");
       const { enqueue } = await import("./dispatch");
       enqueue(taskId);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -302,3 +302,11 @@ export const DEFAULT_SETTINGS: SettingsConfig = {
   stall_timeout_minutes: 5,
   max_retries: 2,
 };
+
+/** Statuses from which a task should never be re-dispatched or re-processed */
+export const TERMINAL_STATUSES: readonly string[] = ["done", "completed", "merged", "failed"] as const;
+
+/** Check if a task status is terminal (should not be re-dispatched to a worker) */
+export function isTerminalStatus(status: string): boolean {
+  return (TERMINAL_STATUSES as readonly string[]).includes(status);
+}

--- a/tests/broker/dispatch.test.ts
+++ b/tests/broker/dispatch.test.ts
@@ -1,0 +1,121 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { Database } from "../../src/broker/db";
+import { SCHEMA_SQL } from "../../src/broker/schema-sql";
+import { bus } from "../../src/broker/event-bus";
+import { join } from "node:path";
+import { unlinkSync, existsSync } from "node:fs";
+
+const TEST_DB = join(import.meta.dir, "dispatch-test.db");
+
+let db: Database;
+
+beforeEach(() => {
+  if (existsSync(TEST_DB)) unlinkSync(TEST_DB);
+  db = new Database(TEST_DB);
+  db.initFromString(SCHEMA_SQL);
+
+  // Seed a tree
+  db.treeUpsert({ id: "test-tree", name: "Test Tree", path: "/tmp/test-tree", github: "org/repo" });
+});
+
+afterEach(() => {
+  bus.removeAll("task:created");
+  bus.removeAll("worker:ended");
+  bus.removeAll("merge:completed");
+  db.close();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    const f = TEST_DB + suffix;
+    if (existsSync(f)) unlinkSync(f);
+  }
+});
+
+// Helper to create a task at a specific status
+function createTask(id: string, status: string, opts: { treeId?: string; dependsOn?: string } = {}) {
+  db.run(
+    "INSERT INTO tasks (id, title, status, tree_id, depends_on) VALUES (?, ?, ?, ?, ?)",
+    [id, `Task ${id}`, status, opts.treeId ?? "test-tree", opts.dependsOn ?? null]
+  );
+}
+
+describe("Terminal state guards", () => {
+  test("dispatch endpoint rejects tasks in 'done' state", async () => {
+    createTask("W-001", "done");
+
+    // Simulate what the /api/tasks/:id/dispatch endpoint does
+    const task = db.taskGet("W-001")!;
+    const { isTerminalStatus } = await import("../../src/shared/types");
+
+    // Task in 'done' should be considered terminal for dispatch
+    expect(isTerminalStatus(task.status)).toBe(true);
+  });
+
+  test("dispatch endpoint rejects tasks in 'failed' state", async () => {
+    createTask("W-001", "failed");
+
+    const task = db.taskGet("W-001")!;
+    const { isTerminalStatus } = await import("../../src/shared/types");
+
+    expect(isTerminalStatus(task.status)).toBe(true);
+  });
+
+  test("dispatch endpoint rejects tasks in 'completed' state", async () => {
+    createTask("W-001", "completed");
+
+    const task = db.taskGet("W-001")!;
+    const { isTerminalStatus } = await import("../../src/shared/types");
+
+    expect(isTerminalStatus(task.status)).toBe(true);
+  });
+
+  test("dispatch endpoint rejects tasks in 'merged' state", async () => {
+    createTask("W-001", "merged");
+
+    const task = db.taskGet("W-001")!;
+    const { isTerminalStatus } = await import("../../src/shared/types");
+
+    expect(isTerminalStatus(task.status)).toBe(true);
+  });
+
+  test("dispatch endpoint allows tasks in 'planned' state", async () => {
+    createTask("W-001", "planned");
+
+    const task = db.taskGet("W-001")!;
+    const { isTerminalStatus } = await import("../../src/shared/types");
+
+    expect(isTerminalStatus(task.status)).toBe(false);
+  });
+
+  test("dispatch endpoint allows tasks in 'ready' state", async () => {
+    createTask("W-001", "ready");
+
+    const task = db.taskGet("W-001")!;
+    const { isTerminalStatus } = await import("../../src/shared/types");
+
+    expect(isTerminalStatus(task.status)).toBe(false);
+  });
+
+  test("getNewlyUnblocked excludes tasks in terminal states", () => {
+    createTask("W-001", "merged");
+    createTask("W-002", "done", { dependsOn: "W-001" });
+    createTask("W-003", "failed", { dependsOn: "W-001" });
+    createTask("W-004", "planned", { dependsOn: "W-001" });
+
+    const unblocked = db.getNewlyUnblocked("W-001");
+
+    // Only W-004 (planned) should be unblocked; W-002 (done) and W-003 (failed) are terminal
+    expect(unblocked.length).toBe(1);
+    expect(unblocked[0].id).toBe("W-004");
+  });
+
+  test("pipeline skips task if DB status is no longer 'done'", () => {
+    // Scenario: worker:ended fires with status "done" but task has already been
+    // set to "failed" by another process (e.g., health monitor race)
+    createTask("W-001", "failed");
+
+    const task = db.taskGet("W-001")!;
+
+    // Pipeline should check DB status and skip
+    expect(task.status).toBe("failed");
+    expect(task.status !== "done").toBe(true);
+  });
+});


### PR DESCRIPTION
## Bug: broker re-processes tasks in terminal states ($done/$fail)

Broker does not skip tasks already in $done/$fail, causing them to be re-processed and marked failed. GitHub issue: bpamiri/grove#5

**Task:** W-016
**Path:** development
**Cost:** $0.00
**Files changed:** 11

### Quality Gates
- commits: passed — 1 commit on branch
- tests: passed — No test command configured — skipped
- diff_size: passed — 145 lines changed

---
*Created by [Grove](https://grove.cloud)*