### PR TITLE
feat: (W-017) Bug: pipeline step transitions reset tree filter in task...

### DIFF
--- a/web/src/hooks/useTasks.ts
+++ b/web/src/hooks/useTasks.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import type { WsMessage } from "./useWebSocket";
 import { api } from "../api/client";
 
@@ -54,11 +54,13 @@ export function useTasks() {
   const [trees, setTrees] = useState<Tree[]>([]);
   const [status, setStatus] = useState<Status | null>(null);
   const [selectedTree, setSelectedTree] = useState<string | null>(null);
+  const selectedTreeRef = useRef<string | null>(null);
 
   const refresh = useCallback(async () => {
     try {
+      const tree = selectedTreeRef.current;
       const [tasksData, treesData, statusData] = await Promise.all([
-        api<Task[]>(selectedTree ? `/api/tasks?tree=${selectedTree}` : "/api/tasks"),
+        api<Task[]>(tree ? `/api/tasks?tree=${tree}` : "/api/tasks"),
         api<Tree[]>("/api/trees"),
         api<Status>("/api/status"),
       ]);
@@ -68,17 +70,21 @@ export function useTasks() {
     } catch {
       // API not available
     }
-  }, [selectedTree]);
+  }, []);
 
   useEffect(() => {
+    selectedTreeRef.current = selectedTree;
     refresh();
-  }, [refresh]);
+  }, [selectedTree, refresh]);
 
   const handleWsMessage = useCallback((msg: WsMessage) => {
     switch (msg.type) {
-      case "task:created":
-        setTasks(prev => [msg.data.task, ...prev]);
+      case "task:created": {
+        const task = msg.data.task;
+        if (selectedTreeRef.current && task.tree_id !== selectedTreeRef.current) break;
+        setTasks(prev => [task, ...prev]);
         break;
+      }
       case "task:status":
         setTasks(prev =>
           prev.map(t => t.id === msg.data.taskId ? { ...t, status: msg.data.status } : t)


### PR DESCRIPTION
## Bug: pipeline step transitions reset tree filter in task list

When a task transitions between steps, the center pane reloads and drops the tree filter, showing all tasks in the selected status instead of just the filtered tree. GitHub issue: bpamiri/grove#6

**Task:** W-017
**Path:** development
**Cost:** $0.00
**Files changed:** 12

### Quality Gates
- commits: passed — 1 commit on branch
- tests: passed — No test command configured — skipped
- diff_size: passed — 18 lines changed

---
*Created by [Grove](https://grove.cloud)*