### PR TITLE
feat: (W-019) Persist all user UI state across page refresh

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,8 +1,9 @@
-import { useState, useCallback } from "react";
+import { useCallback } from "react";
 import { useWebSocket, type WsMessage } from "./hooks/useWebSocket";
 import { useTasks } from "./hooks/useTasks";
 import { useChat } from "./hooks/useChat";
 import { usePaneSizes } from "./hooks/usePaneSizes";
+import { useLocalStorage } from "./hooks/useLocalStorage";
 import Sidebar from "./components/Sidebar";
 import TaskList from "./components/TaskList";
 import Chat from "./components/Chat";
@@ -12,7 +13,7 @@ import ResizeHandle from "./components/ResizeHandle";
 type View = "tasks" | "settings";
 
 export default function App() {
-  const [view, setView] = useState<View>("tasks");
+  const [view, setView] = useLocalStorage<View>("grove-ui-view", "tasks");
   const taskState = useTasks();
   const { connected, send } = useWebSocket({
     onMessage: useCallback((msg: WsMessage) => {

--- a/web/src/components/TaskList.tsx
+++ b/web/src/components/TaskList.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { Task } from "../hooks/useTasks";
+import { useLocalStorage } from "../hooks/useLocalStorage";
 import TaskDetail from "./TaskDetail";
 import Pipeline from "./Pipeline";
 
@@ -32,7 +33,7 @@ const STATUS_BORDER: Record<string, string> = {
 
 export default function TaskList({ tasks, getActivity, onRefresh }: Props) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
-  const [filter, setFilter] = useState<"all" | "active" | "done">("all");
+  const [filter, setFilter] = useLocalStorage<"all" | "active" | "done">("grove-ui-task-filter", "all");
 
   const filtered = tasks.filter((t) => {
     if (filter === "active") return ["planned", "ready", "running", "paused", "evaluating"].includes(t.status);

--- a/web/src/hooks/useLocalStorage.ts
+++ b/web/src/hooks/useLocalStorage.ts
@@ -1,0 +1,34 @@
+import { useState, useCallback } from "react";
+
+/**
+ * useState backed by localStorage. Reads the stored value on first render;
+ * writes on every state change. Falls back to `defaultValue` when the key
+ * is missing or the stored JSON is unparseable.
+ */
+export function useLocalStorage<T>(key: string, defaultValue: T) {
+  const [value, setValue] = useState<T>(() => {
+    try {
+      const stored = localStorage.getItem(key);
+      return stored !== null ? (JSON.parse(stored) as T) : defaultValue;
+    } catch {
+      return defaultValue;
+    }
+  });
+
+  const set = useCallback(
+    (next: T | ((prev: T) => T)) => {
+      setValue((prev) => {
+        const resolved = typeof next === "function" ? (next as (prev: T) => T)(prev) : next;
+        try {
+          localStorage.setItem(key, JSON.stringify(resolved));
+        } catch {
+          // Storage full or unavailable — state still updates in memory
+        }
+        return resolved;
+      });
+    },
+    [key],
+  );
+
+  return [value, set] as const;
+}

--- a/web/src/hooks/useTasks.ts
+++ b/web/src/hooks/useTasks.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { WsMessage } from "./useWebSocket";
+import { useLocalStorage } from "./useLocalStorage";
 import { api } from "../api/client";
 
 export interface Task {
@@ -53,7 +54,7 @@ export function useTasks() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [trees, setTrees] = useState<Tree[]>([]);
   const [status, setStatus] = useState<Status | null>(null);
-  const [selectedTree, setSelectedTree] = useState<string | null>(null);
+  const [selectedTree, setSelectedTree] = useLocalStorage<string | null>("grove-ui-selected-tree", null);
   const selectedTreeRef = useRef<string | null>(null);
 
   const refresh = useCallback(async () => {
@@ -76,6 +77,13 @@ export function useTasks() {
     selectedTreeRef.current = selectedTree;
     refresh();
   }, [selectedTree, refresh]);
+
+  // Reset persisted tree selection if the tree no longer exists
+  useEffect(() => {
+    if (selectedTree && trees.length > 0 && !trees.some((t) => t.id === selectedTree)) {
+      setSelectedTree(null);
+    }
+  }, [trees, selectedTree, setSelectedTree]);
 
   const handleWsMessage = useCallback((msg: WsMessage) => {
     switch (msg.type) {


### PR DESCRIPTION
## Persist all user UI state across page refresh

Retain tree selection, status filter, and other UI preferences on refresh via localStorage. Extends #7 (pane sizes) to full UI state. GitHub issue: bpamiri/grove#9

**Task:** W-019
**Path:** development
**Cost:** $0.00
**Files changed:** 15

### Quality Gates
- commits: passed — 1 commit on branch
- tests: passed — No test command configured — skipped
- diff_size: passed — 52 lines changed

---
*Created by [Grove](https://grove.cloud)*