### PR TITLE
fix: add missing build:embed step to CI build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,10 +53,15 @@ jobs:
       - name: Build web assets
         run: bun run build:web
 
-      - name: Build binary (${{ matrix.target }})
+      - name: Embed web assets
+        run: bun run build:embed
+
+      - name: Build binary
+        env:
+          TARGET: ${{ matrix.target }}
         run: |
           mkdir -p bin
-          bun build src/cli/index.ts --compile --target=${{ matrix.target }} --outfile bin/grove
+          bun build src/cli/index.ts --compile --target="$TARGET" --outfile bin/grove
 
       - name: Upload binary
         uses: actions/upload-artifact@v4
@@ -92,8 +97,9 @@ jobs:
       - name: Create or update release
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          tag="v${{ steps.version.outputs.version }}"
+          tag="v${VERSION}"
           if gh release view "$tag" &>/dev/null; then
             gh release upload "$tag" release/* --clobber
           else


### PR DESCRIPTION
## Summary

- The Build workflow on main fails because it compiles the binary without first running `build:embed`, which generates `web-assets.generated.ts`
- Error: `Could not resolve: "./web-assets.generated"` at `src/broker/server.ts:10`
- Fix: add `bun run build:embed` step between `build:web` and binary compilation
- Also moved `matrix.target` into env var for the `run:` command

## Test plan

- [ ] Build workflow passes on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)