### PR TITLE
fix: use RELEASE_PAT in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PAT }}
 
       - uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Summary
- Swap `GITHUB_TOKEN` for `RELEASE_PAT` in release workflow checkout
- `GITHUB_TOKEN` cannot push to protected branches; the fine-grained PAT bypasses the "require PRs" rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)