### PR TITLE
chore: reset version to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grove-ai/cli",
-  "version": "3.0.1",
+  "version": "0.1.0",
   "type": "module",
   "main": "src/cli/index.ts",
   "bin": {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -291,7 +291,7 @@ export interface EventBusMap {
 // Constants
 // ---------------------------------------------------------------------------
 
-export const GROVE_VERSION = "3.0.1";
+export const GROVE_VERSION = "0.1.0";
 
 export const DEFAULT_PATHS: Record<string, PathConfig> = {
   development: {


### PR DESCRIPTION
## Summary
- Reset version from 3.0.1 to 0.1.0
- 3.x was a placeholder from early development
- 0.1.0 signals early-stage, working software with no stability guarantees

After merging, trigger the Release workflow to publish v0.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)