### PR TITLE
docs: full documentation set + README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,226 +1,100 @@
 # Grove
 
-**Conversational AI development orchestrator.** Install, run, get a URL. Manage your coding agents from anywhere.
+**Conversational AI development orchestrator.** Manage your coding agents from anywhere through a real-time web GUI.
 
-Grove gives you a head agent (the orchestrator) that you chat with to plan work, decompose tasks across repos, and delegate to Claude Code workers — all observable through a real-time web GUI accessible via secure tunnel.
+Grove gives you a head agent (the orchestrator) that you chat with to plan work, decompose tasks across repos, and delegate to Claude Code workers — all observable through a web GUI accessible via secure tunnel.
 
-> **Status:** Alpha (v3.0.0-alpha.0). Core infrastructure works. Actively iterating on the orchestrator prompt and worker sandbox.
+> **Status:** Alpha (v0.1.1). Core infrastructure works. Actively iterating.
 
 ## Quick Start
 
 ```bash
-# Clone and build
-git clone https://github.com/bpamiri/grove.git
-cd grove
-bun install
-cd web && bun install && cd ..
-bun run build
+# Install (macOS Apple Silicon)
+curl -fsSL https://github.com/bpamiri/grove/releases/latest/download/grove-darwin-arm64.tar.gz | tar xz
+chmod +x grove && sudo mv grove /usr/local/bin/
 
-# Initialize
-bin/grove init
-
-# Add your repos
-bin/grove tree add ~/code/my-project
-
-# Start everything
-bin/grove up
+# Initialize and start
+grove init
+grove tree add ~/code/my-project
+grove up
 ```
 
-On `grove up`:
-
-```
-  ✓ Broker started (PID 12345)
-  ✓ Orchestrator spawned in tmux:grove
-  ✓ Tunnel active
-
-  Local:   http://localhost:49231
-  Remote:  https://grove-a1b2c3.trycloudflare.com
-  Token:   k8m2x9p4...
-  tmux:    tmux attach -t grove
-```
-
-Open the URL in a browser or on your phone. Chat with the orchestrator. Watch workers implement tasks in real-time.
+See [Installation](docs/getting-started/installation.md) for all platforms and build-from-source instructions.
 
 ## Architecture
 
 ```
-You ─── Browser (GUI) ─── Tunnel ───┐
-  │                                   │
-  ├── tmux attach ──────────────┐     │
-  │                              │     │
-  └── grove CLI ────────────┐    │     │
-                             │    │     │
-                             ▼    ▼     ▼
-                   ┌──────────────────────────┐
-                   │    Broker (Bun process)    │
-                   │                           │
-                   │  Web+WS · SQLite · tmux   │
-                   │  Monitor · Merge Manager  │
-                   └───────────┬───────────────┘
-                               │
-            ┌──────────────────┼──────────────────┐
-            ▼                  ▼                   ▼
-      Orchestrator        Worker(s)           Evaluator
-      (Claude Code)     (Claude Code)       (Claude Code)
-      persistent        ephemeral           on-demand
+You --- Browser (GUI) --- Tunnel ---+
+  |                                  |
+  +-- tmux attach ---------+        |
+  |                         |        |
+  +-- grove CLI -------+    |        |
+                        |    |        |
+                        v    v        v
+              +---------------------------+
+              |    Broker (Bun process)    |
+              |                           |
+              |  HTTP+WS . SQLite . tmux  |
+              |  Monitor . Merge Manager  |
+              +----------+----------------+
+                         |
+          +--------------+--------------+
+          v              v              v
+    Orchestrator     Worker(s)      Evaluator
+    (Claude Code)  (Claude Code)  (Claude Code)
+    persistent     ephemeral      on-demand
 ```
 
 The system separates **infrastructure** from **intelligence**:
 
-- **Broker** — Bun process managing tmux sessions, HTTP+WebSocket server, SQLite state, tunnel, health/cost monitoring, and merge queue. Stable, lightweight, never makes decisions.
-- **Orchestrator** — Interactive Claude Code session in tmux. You chat with it to plan and delegate. It has read-only access to all your repos.
-- **Workers** — Ephemeral Claude Code sessions. Each gets an isolated git worktree with a sandboxed environment. Full toolset within the worktree boundary.
-- **Evaluator** — Spawned after a worker completes. Runs quality gates (commits, tests, lint, diff size). Separate agent because models are poor critics of their own output.
-- **Monitor** — Broker-native health checks: PID liveness, stall detection, cost tracking, auto-restart.
-- **Merge Manager** — Broker-native PR lifecycle: push, create PR, watch CI, merge on green. Sequential per-repo to prevent conflicts.
-
-## Concepts
-
-### Trees
-
-Trees are repos under Grove management. A grove is a collection of trees.
-
-```yaml
-# ~/.grove/grove.yaml
-trees:
-  api-server:
-    path: ~/code/api-server
-    github: myorg/api-server
-    branch_prefix: grove/
-    quality_gates:
-      tests: true
-      lint: true
-
-  frontend:
-    path: ~/code/frontend
-    github: myorg/frontend
-```
-
-### Paths
-
-Paths are workflow templates. Different task types follow different pipelines.
-
-```yaml
-paths:
-  development:              # plan → implement → evaluate → merge
-    steps: [plan, implement, evaluate, merge]
-
-  research:                 # plan → research → report (no code changes)
-    steps: [plan, research, report]
-
-  content:                  # plan → implement → evaluate → publish
-    steps: [plan, implement, evaluate, publish]
-```
-
-Built-in paths ship with Grove. Create custom ones in `grove.yaml`.
-
-### Task Lifecycle
-
-```
-planned → ready → running → done → evaluating → merged
-                    ↓                     ↓
-                  paused              ci_failed → retry
-                    ↓
-                  failed
-```
-
-- Hard gate failure (no commits, tests fail) → auto-retry up to `max_retries`
-- Soft gate failure (lint warnings, diff too large) → pass through with warnings
-- CI failure → orchestrator decides: retry worker or escalate to user
-
-## Web GUI
-
-Three-panel layout served by the broker:
-
-- **Left sidebar** — Tree list, system status (broker, orchestrator, workers, cost), navigation
-- **Center** — Task cards with live status, activity stream, pipeline progress, expandable detail with gate results and file diffs
-- **Right** — Orchestrator chat with message history, relayed to/from the tmux session
-
-Real-time updates via WebSocket. Accessible remotely through the tunnel.
+- **Broker** — Bun process managing HTTP+WebSocket server, SQLite state, tmux sessions, tunnel, health/cost monitoring, and merge queue. Stable, lightweight, never makes decisions.
+- **Orchestrator** — Persistent Claude Code session. You chat with it to plan and delegate.
+- **Workers** — Ephemeral Claude Code sessions in isolated git worktrees with sandboxed guard hooks.
+- **Evaluator** — Runs quality gates (tests, lint, diff size) on worker output. Separate agent because models are poor critics of their own output.
 
 ## CLI
 
 | Command | Purpose |
 |---------|---------|
-| `grove init` | Initialize `~/.grove/` with config and database |
-| `grove up` | Start broker, orchestrator, and tunnel |
+| `grove init` | Initialize `~/.grove/` |
+| `grove up` | Start broker + orchestrator + tunnel |
 | `grove down` | Graceful shutdown |
 | `grove status` | Broker health, workers, costs |
-| `grove trees` | List configured trees |
-| `grove tree add <path>` | Add a repo (auto-detects GitHub remote) |
-| `grove tasks` | List tasks with filtering |
-| `grove task add "title"` | Create a new task |
+| `grove trees` | List configured trees (repos) |
+| `grove tree add <path>` | Add a repo |
+| `grove tasks` | List tasks |
+| `grove task add "title"` | Create a task |
 | `grove chat "message"` | Message the orchestrator |
-| `grove cost` | Spend breakdown (today, week) |
-
-Most interaction happens through the orchestrator — via the GUI chat, tmux, or `grove chat`.
+| `grove cost` | Spend breakdown |
+| `grove upgrade` | Update to latest version |
 
 ## Requirements
 
-- **[Bun](https://bun.sh/)** >= 1.0 — runtime and build tool
-- **[Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code)** — the agent runtime (requires Claude subscription)
-- **[tmux](https://github.com/tmux/tmux)** — terminal multiplexer for agent sessions
-- **[git](https://git-scm.com/)** — version control and worktree isolation
-- **[gh](https://cli.github.com/)** — GitHub CLI for PR management
-- **[cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/)** — tunnel for remote access (optional)
+- **[Bun](https://bun.sh/)** >= 1.0
+- **[Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code)**
+- **[tmux](https://github.com/tmux/tmux)**
+- **[git](https://git-scm.com/)**
+- **[gh](https://cli.github.com/)** (optional, for PR management)
+- **[cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/)** (optional, for remote access)
 
-## Configuration
+## Documentation
 
-See [`grove.yaml.example`](grove.yaml.example) for all options:
-
-- **trees** — repos under management
-- **paths** — workflow templates (built-ins + custom)
-- **budgets** — cost controls (per task: $5, daily: $25, weekly: $100 defaults)
-- **server** — port (`auto` picks a random available port)
-- **tunnel** — provider (cloudflare), auth (token), optional custom domain
-- **settings** — max workers (5), stall timeout (5 min), retry limits (2)
-
-## Security
-
-- Random auth token generated on first `grove up`, stored at `~/.grove/auth.token`
-- Web GUI requires the token (entered once, persisted in browser)
-- Workers sandboxed to their worktree via PreToolUse guard hooks
-- Dangerous commands blocked (`git push`, `sudo`, `rm -rf /`)
-- File writes restricted to the worktree boundary
-- No `git push` from workers — the merge manager handles that
-
-## Influences
-
-- **[Gas Town](https://github.com/steveyegge/gastown)** (Steve Yegge) — multi-agent orchestration, rig/tree concept, open-source distribution model
-- **[Anthropic harness design](https://www.anthropic.com/engineering/harness-design-long-running-apps)** — Planner/Generator/Evaluator pattern, GAN-inspired separation of building from judging
-- **Claude Code** — native capabilities (hooks, MCP, permissions) leveraged rather than rebuilt
+- **Getting Started**
+  - [Installation](docs/getting-started/installation.md)
+  - [Quick Start](docs/getting-started/quick-start.md)
+  - [Upgrading](docs/getting-started/upgrading.md)
+- **Guides**
+  - [Configuration](docs/guides/configuration.md)
+  - [CLI Reference](docs/guides/cli-reference.md)
+  - [Architecture](docs/guides/architecture.md)
+  - [Security](docs/guides/security.md)
 
 ## Development
 
 ```bash
-# Run from source (no build step)
-bun run dev -- help
-
-# Run tests
-bun run test
-
-# Build binary + frontend
-bun run build
-
-# Type check
-bunx tsc --noEmit
-```
-
-### Project Structure
-
-```
-src/
-  agents/       Orchestrator, worker, evaluator, stream parser
-  broker/       DB, config, HTTP+WS server, tmux, event bus, dispatch, pipeline
-  cli/          Entry point + 9 command files
-  merge/        GitHub CLI wrapper + merge queue manager
-  monitor/      Health checks + cost tracking
-  shared/       Types, worktree, sandbox (guard hooks + overlays)
-  tunnel/       Cloudflare tunnel provider
-web/
-  src/          React + Vite + Tailwind SPA
-tests/
-  broker/       Unit tests (37 tests)
+bun run dev -- help    # Run from source
+bun run test           # Run tests (96 tests)
+bun run build          # Build binary + frontend
 ```
 
 ## License

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,68 @@
+# Installation
+
+## Prerequisites
+
+| Tool | Required | Install |
+|------|----------|---------|
+| **Bun** >= 1.0 | Yes | `curl -fsSL https://bun.sh/install \| bash` |
+| **tmux** | Yes | `brew install tmux` (macOS) / `apt install tmux` (Linux) |
+| **Claude Code CLI** | Yes | `npm install -g @anthropic-ai/claude-code` (requires Anthropic subscription) |
+| **git** | Yes | Usually pre-installed |
+| **gh** | No | `brew install gh` / `apt install gh` |
+| **cloudflared** | No | `brew install cloudflare/cloudflare/cloudflared` |
+
+## Install from Binary (recommended)
+
+```bash
+# macOS (Apple Silicon)
+curl -fsSL https://github.com/bpamiri/grove/releases/latest/download/grove-darwin-arm64.tar.gz | tar xz
+chmod +x grove
+sudo mv grove /usr/local/bin/
+
+# macOS (Intel)
+curl -fsSL https://github.com/bpamiri/grove/releases/latest/download/grove-darwin-x64.tar.gz | tar xz
+chmod +x grove
+sudo mv grove /usr/local/bin/
+
+# Linux (x64)
+curl -fsSL https://github.com/bpamiri/grove/releases/latest/download/grove-linux-x64.tar.gz | tar xz
+chmod +x grove
+sudo mv grove /usr/local/bin/
+```
+
+Verify: `grove --version`
+
+## Build from Source
+
+```bash
+git clone https://github.com/bpamiri/grove.git
+cd grove
+bun install
+cd web && bun install && cd ..
+bun run build
+```
+
+This produces `bin/grove`. Optionally symlink it:
+
+```bash
+ln -s $(pwd)/bin/grove /usr/local/bin/grove
+```
+
+## Run from Source (development)
+
+No build step needed:
+
+```bash
+bun run dev -- help
+```
+
+## Verify Installation
+
+```bash
+grove --version    # Should print: grove 0.1.1
+grove help         # Shows all commands
+```
+
+## Next Steps
+
+[Quick Start](quick-start.md)

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,0 +1,88 @@
+# Quick Start
+
+## Initialize Grove
+
+```bash
+grove init
+```
+
+Creates `~/.grove/` with:
+- `grove.yaml` — configuration file
+- `grove.db` — SQLite database for task state
+- `logs/` — session logs
+
+## Add Your Repositories
+
+Grove manages repos as "trees" — a grove is a collection of trees.
+
+```bash
+grove tree add ~/code/my-project
+```
+
+Auto-detects the GitHub remote and registers the tree. Add multiple repos:
+
+```bash
+grove tree add ~/code/api-server
+grove tree add ~/code/frontend
+grove trees   # List all trees
+```
+
+Options:
+- `--github org/repo` — override remote detection
+- `--name my-name` — override auto-generated ID
+
+## Start Grove
+
+```bash
+grove up
+```
+
+```
+  Grove v0.1.1
+
+  Broker started (PID 12345)
+  Orchestrator spawned in tmux:grove
+  Tunnel active
+
+  Local:   http://localhost:49231
+  Tunnel:  https://random.trycloudflare.com
+  tmux:    tmux attach -t grove
+```
+
+Three ways to interact:
+
+1. **Web GUI** — open the Local URL in a browser
+2. **tmux** — `tmux attach -t grove` for direct orchestrator terminal
+3. **CLI** — `grove chat "message"` from any terminal
+
+## Chat with the Orchestrator
+
+```bash
+grove chat "Add error handling to the auth module in api-server"
+```
+
+Or use the web GUI's chat panel, or the tmux session directly. The orchestrator plans the work, decomposes it into tasks, and delegates to workers.
+
+## Monitor Progress
+
+```bash
+grove status    # Broker health, workers, costs
+grove tasks     # List all tasks with status
+grove cost      # Spend breakdown
+```
+
+The web GUI shows real-time updates via WebSocket.
+
+## Stop Grove
+
+```bash
+grove down
+```
+
+Gracefully stops the broker, orchestrator, workers, and tunnel.
+
+## Next Steps
+
+- [Configuration](../guides/configuration.md) — customize trees, paths, budgets, tunnel
+- [CLI Reference](../guides/cli-reference.md) — all commands
+- [Architecture](../guides/architecture.md) — how it all works

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -1,0 +1,64 @@
+# Upgrading
+
+## Self-Update
+
+Grove can update itself in place:
+
+```bash
+grove upgrade
+```
+
+This:
+1. Checks GitHub Releases for the latest version
+2. Downloads the platform-specific binary
+3. Verifies SHA256 checksum
+4. Replaces the current binary
+
+If you get a permission error:
+
+```bash
+sudo grove upgrade
+```
+
+## Update Checks
+
+On every `grove up`, Grove checks for newer versions in the background (non-blocking). If one exists, you'll see:
+
+```
+  Grove v0.2.0 available. Run 'grove upgrade' to update.
+```
+
+The check is cached for 24 hours at `~/.grove/update-check.json`.
+
+### Disabling Update Checks
+
+Set the environment variable:
+
+```bash
+export GROVE_NO_UPDATE_CHECK=1
+```
+
+Update checks are also skipped automatically in non-TTY environments (CI pipelines, scripts).
+
+## Manual Update (from source)
+
+If you built from source:
+
+```bash
+cd grove
+git pull
+bun install
+cd web && bun install && cd ..
+bun run build
+```
+
+## Supported Platforms
+
+| Platform | Architecture | Binary |
+|----------|-------------|--------|
+| macOS | Apple Silicon (arm64) | `grove-darwin-arm64` |
+| macOS | Intel (x64) | `grove-darwin-x64` |
+| Linux | x64 | `grove-linux-x64` |
+| Windows | x64 | `grove-windows-x64` |
+
+Windows binary is available but Grove does not yet support Windows at runtime (pending tmux removal — see issue #23).

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -1,0 +1,113 @@
+# Architecture
+
+## Overview
+
+Grove separates **infrastructure** from **intelligence**. The broker handles all infrastructure (HTTP, database, tunnels, process management) while Claude Code agents handle all decision-making.
+
+```
+You --- Browser (GUI) --- Tunnel ---+
+  |                                  |
+  +-- tmux attach ---------+        |
+  |                         |        |
+  +-- grove CLI -------+    |        |
+                        |    |        |
+                        v    v        v
+              +---------------------------+
+              |    Broker (Bun process)    |
+              |                           |
+              |  HTTP+WS . SQLite . tmux  |
+              |  Monitor . Merge Manager  |
+              +----------+----------------+
+                         |
+          +--------------+--------------+
+          v              v              v
+    Orchestrator     Worker(s)      Evaluator
+    (Claude Code)  (Claude Code)  (Claude Code)
+    persistent     ephemeral      on-demand
+```
+
+## Components
+
+### Broker
+
+The central Bun process. Lightweight, stable, never makes decisions. Manages:
+
+- **HTTP + WebSocket server** — serves the web GUI, REST API (`/api/*`), and real-time updates
+- **SQLite database** — task state, tree config, events, messages (via `bun:sqlite`)
+- **tmux sessions** — orchestrator and worker panes
+- **Step engine** — drives tasks through configurable pipelines (plan -> implement -> evaluate -> merge)
+- **Dispatch queue** — manages concurrent worker slots (default: 5)
+- **Health monitor** — detects stalled workers via PID liveness checks and stall timeouts
+- **Cost monitor** — tracks Claude API spend against per-task, daily, and weekly budgets
+- **Merge manager** — pushes branches, creates PRs, watches CI, merges on green (sequential per-repo)
+- **Tunnel** — optional Cloudflare quick tunnel for remote access
+
+State persisted to `~/.grove/broker.json` (PID, port, URLs) and `~/.grove/grove.db` (tasks, trees, events).
+
+### Orchestrator
+
+A persistent Claude Code session running in tmux. You chat with it to:
+- Plan and decompose work across repos
+- Create and prioritize tasks
+- Review worker output and make decisions
+
+The orchestrator has read-only awareness of all configured trees. It communicates with the broker via structured JSONL events on stdout.
+
+### Workers
+
+Ephemeral Claude Code sessions. Each worker:
+- Gets an isolated git worktree (branch from the tree's default branch)
+- Runs in a sandboxed environment with guard hooks
+- Executes one pipeline step (plan, implement, etc.)
+- Commits changes and reports back
+- Is killed after completing its step
+
+Workers cannot push to remote. The merge manager handles that.
+
+### Evaluator
+
+Spawned after a worker completes. Runs quality gates:
+- **Commits** — checks for conventional commit format
+- **Tests** — runs the tree's test command
+- **Lint** — runs the tree's lint command
+- **Diff size** — rejects changes that are too large or too small
+
+Separate from the worker because models are poor critics of their own output.
+
+Gate results: pass (advance to next step), fail (retry worker up to `max_retries`), or skip (soft warnings pass through).
+
+## Data Flow
+
+1. You create a task (via GUI, CLI, or orchestrator)
+2. The step engine picks the task's path (e.g., `development`)
+3. Dispatch assigns the first step to an available worker slot
+4. Worker executes in an isolated worktree, commits, reports completion
+5. Evaluator runs quality gates on the worker's output
+6. If gates pass, the step engine advances to the next step
+7. Merge manager pushes the branch, creates a PR, monitors CI
+8. On CI green, the PR is merged and the task is marked complete
+
+## Web GUI
+
+Three-panel layout served by the broker at `http://localhost:{port}`:
+
+- **Left sidebar** — tree list, system status, navigation
+- **Center** — task cards with live status, activity stream, pipeline progress
+- **Right** — orchestrator chat
+
+Real-time updates via WebSocket. Accessible remotely through the tunnel with token authentication.
+
+## Process Tree
+
+```
+grove up (foreground)
+  +-- Bun HTTP server (same process)
+  +-- tmux session "grove"
+       +-- orchestrator pane (claude --dangerously-skip-permissions)
+       +-- worker pane 1 (ephemeral)
+       +-- worker pane 2 (ephemeral)
+       +-- ...
+  +-- cloudflared tunnel (child process, optional)
+```
+
+All processes are children of the broker. `grove down` sends SIGTERM to the broker, which cleans up everything.

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -1,0 +1,126 @@
+# CLI Reference
+
+## Global Options
+
+```
+grove --version, -v    Print version
+grove --help, -h       Show help
+grove help             Detailed help with all commands
+```
+
+## Commands
+
+### grove init
+
+Initialize Grove data directory.
+
+```bash
+grove init
+```
+
+Creates `~/.grove/` with configuration, database, and log directory. Safe to run multiple times — exits if already initialized.
+
+---
+
+### grove up
+
+Start the broker, orchestrator, and tunnel.
+
+```bash
+grove up
+```
+
+Starts the Bun HTTP server, spawns the orchestrator in a tmux session named `grove`, and optionally starts a Cloudflare tunnel. Runs in the foreground. Press Ctrl+C to stop.
+
+Also performs a background update check (see [Upgrading](../getting-started/upgrading.md)).
+
+---
+
+### grove down
+
+Gracefully stop everything.
+
+```bash
+grove down
+```
+
+Sends SIGTERM to the broker process, which stops workers, orchestrator, tunnel, and cleans up.
+
+---
+
+### grove status
+
+Show system health.
+
+```bash
+grove status
+```
+
+Displays broker PID, URL, orchestrator state, active worker count, task counts by status, and daily cost.
+
+---
+
+### grove trees / grove tree
+
+List or add repositories.
+
+```bash
+grove trees                              # List all trees
+grove tree add <path>                    # Add a repo
+grove tree add <path> --github org/repo  # Override GitHub remote
+grove tree add <path> --name my-tree     # Override tree ID
+```
+
+`tree add` auto-detects the GitHub remote from `git remote -v`. The tree ID is derived from the directory name (lowercase, special chars replaced with `-`).
+
+---
+
+### grove tasks / grove task
+
+List or create tasks.
+
+```bash
+grove tasks                          # List all tasks
+grove tasks --status running         # Filter by status
+grove tasks --tree api-server        # Filter by tree
+grove task add "Add auth middleware"  # Create a task
+```
+
+Task statuses: `draft`, `queued`, `active`, `completed`, `failed`
+
+---
+
+### grove chat
+
+Send a message to the orchestrator.
+
+```bash
+grove chat "Implement the login feature"
+grove chat "What's the status of the API refactor?"
+```
+
+Messages are relayed to the orchestrator's tmux session. View the response via `tmux attach -t grove` or the web GUI.
+
+---
+
+### grove cost
+
+Show spending breakdown.
+
+```bash
+grove cost
+```
+
+Displays today's spend and this week's spend in USD.
+
+---
+
+### grove upgrade
+
+Update to the latest version.
+
+```bash
+grove upgrade
+```
+
+Downloads the latest release from GitHub, verifies the SHA256 checksum, and replaces the current binary. See [Upgrading](../getting-started/upgrading.md) for details.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1,0 +1,205 @@
+# Configuration
+
+Grove is configured via `~/.grove/grove.yaml`. The file is created automatically by `grove init` with sensible defaults. Edit it directly to customize behavior.
+
+---
+
+## Trees
+
+Trees are repositories under Grove management. Each tree has its own path, GitHub identity, and quality gate configuration.
+
+```yaml
+trees:
+  api-server:
+    path: ~/code/api-server
+    github: myorg/api-server
+    default_branch: main
+    branch_prefix: grove/
+    quality_gates:
+      tests: true
+      lint: true
+      commits: true
+      diff_size: true
+      max_diff_lines: 5000
+      test_command: "npm test"
+      lint_command: "npx eslint ."
+      test_timeout: 300
+      lint_timeout: 60
+```
+
+**Fields:**
+
+| Field | Description |
+|-------|-------------|
+| `path` | Filesystem path to the repo. Supports `~` expansion. |
+| `github` | `org/repo` identifier. Auto-detected from git remote by `grove tree add`. |
+| `default_branch` | Base branch for worktrees. Defaults to auto-detected value from git. |
+| `branch_prefix` | Prefix applied to worker branches. Defaults to the value in `settings.branch_prefix`. |
+| `quality_gates` | Per-tree evaluation criteria (see below). |
+
+**Quality gate fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tests` | bool | Run the test suite during gate evaluation. |
+| `lint` | bool | Run the linter during gate evaluation. |
+| `commits` | bool | Validate commit message format (conventional commits). |
+| `diff_size` | bool | Fail the gate if the diff exceeds `max_diff_lines`. |
+| `max_diff_lines` | int | Line threshold for `diff_size` check. Default: `5000`. |
+| `test_command` | string | Shell command used to run tests. |
+| `lint_command` | string | Shell command used to run the linter. |
+| `test_timeout` | int | Seconds before the test command is killed. Default: `300`. |
+| `lint_timeout` | int | Seconds before the lint command is killed. Default: `60`. |
+
+---
+
+## Paths (Workflow Templates)
+
+Paths define task pipelines — the sequence of steps a task moves through from intake to completion. Grove ships with built-in paths; you can also define custom ones.
+
+```yaml
+paths:
+  development:
+    description: "Standard dev workflow with QA"
+    steps:
+      - id: plan
+        type: worker
+        prompt: "Analyze requirements and outline approach."
+      - id: implement
+        type: worker
+        prompt: "Implement the task. Commit with conventional commits."
+      - id: evaluate
+        type: gate
+        on_failure: implement
+
+  research:
+    description: "Research without code changes"
+    steps: [plan, research, report]
+```
+
+**Step types:**
+
+| Type | Description |
+|------|-------------|
+| `worker` | Spawns a Claude Code worker session to execute the step. |
+| `gate` | Runs quality evaluation (tests, lint, diff size) against the current state. |
+
+**Step fields:**
+
+| Field | Description |
+|-------|-------------|
+| `id` | Unique identifier for the step within the path. |
+| `type` | `worker` or `gate`. |
+| `prompt` | Instructions passed to the worker (worker steps only). |
+| `on_failure` | Step ID to retry when this gate fails. |
+
+**String shorthand:** The `steps` list accepts bare step IDs as strings (`steps: [plan, implement, evaluate]`). Grove expands these to full `PipelineStep` objects using built-in defaults for each named step.
+
+**Built-in paths:**
+
+| Path | Steps | Description |
+|------|-------|-------------|
+| `development` | plan -> implement -> evaluate -> merge | Standard dev workflow with QA gate |
+| `research` | plan -> research -> report | Research task, no code changes |
+
+---
+
+## Budgets
+
+Cost controls prevent runaway spending across tasks and sessions. All values are in USD.
+
+```yaml
+budgets:
+  per_task: 5.00
+  per_session: 10.00
+  per_day: 25.00
+  per_week: 100.00
+  auto_approve_under: 2.00
+```
+
+| Field | Description |
+|-------|-------------|
+| `per_task` | Maximum spend for a single task before it is paused for approval. |
+| `per_session` | Maximum spend across all tasks in one Grove session. |
+| `per_day` | Rolling 24-hour spend ceiling. |
+| `per_week` | Rolling 7-day spend ceiling. |
+| `auto_approve_under` | Tasks estimated below this cost start without prompting for approval. |
+
+---
+
+## Server
+
+```yaml
+server:
+  port: auto
+```
+
+Set `port` to `auto` to let Grove pick a random available port on startup, or provide a specific port number. The active port is written to `~/.grove/broker.json` at runtime.
+
+---
+
+## Tunnel
+
+Grove can expose its local server over a Cloudflare tunnel for remote access or webhook ingestion.
+
+```yaml
+tunnel:
+  provider: cloudflare
+  auth: token
+  domain: grove.cloud
+  subdomain: auto
+  secret: auto
+```
+
+| Field | Description |
+|-------|-------------|
+| `provider` | Tunnel provider. Currently `cloudflare` only. |
+| `auth` | Authentication method. `token` uses a Cloudflare API token. |
+| `domain` | Optional base domain. Register `grove.cloud` for a stable vanity URL. |
+| `subdomain` | Subdomain to use. `auto` generates one on first start and persists it. |
+| `secret` | Shared secret for webhook validation. `auto` generates one on first start. |
+
+Requires `cloudflared` to be installed and on `$PATH`. If tunnel setup fails, Grove logs the error and continues with localhost-only access.
+
+---
+
+## Settings
+
+Global defaults that apply across all trees unless overridden at the tree level.
+
+```yaml
+settings:
+  max_workers: 5
+  branch_prefix: grove/
+  stall_timeout_minutes: 5
+  max_retries: 2
+```
+
+| Field | Description |
+|-------|-------------|
+| `max_workers` | Maximum number of concurrent Claude Code worker sessions. |
+| `branch_prefix` | Default git branch prefix for worker worktrees. Overridable per tree. |
+| `stall_timeout_minutes` | Health monitor flags a worker as stuck after this many minutes without output. |
+| `max_retries` | Number of times Grove will automatically retry a failed gate before surfacing the failure. |
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GROVE_HOME` | `~/.grove` | Override the Grove data directory. |
+| `GROVE_NO_UPDATE_CHECK` | unset | Set to `1` to disable automatic version checks. |
+
+---
+
+## File Locations
+
+| File | Purpose |
+|------|---------|
+| `~/.grove/grove.yaml` | Main configuration file. |
+| `~/.grove/grove.db` | SQLite database storing task state and history. |
+| `~/.grove/auth.token` | Authentication token for the Grove API. |
+| `~/.grove/broker.json` | Runtime broker info: PID, port, tunnel URLs. Recreated on each start. |
+| `~/.grove/update-check.json` | Cached result of the last version check. |
+| `~/.grove/logs/` | Per-session worker logs. |

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -1,0 +1,77 @@
+# Security
+
+## Authentication
+
+Grove generates a random 32-character alphanumeric token on first `grove up`, stored at `~/.grove/auth.token` with permissions `0600` (owner read/write only).
+
+The web GUI requires this token for access. When connecting remotely via tunnel, append it as a query parameter:
+
+```
+https://your-tunnel-url?token=YOUR_TOKEN
+```
+
+Local connections (localhost) are pre-authenticated.
+
+To rotate the token, delete `~/.grove/auth.token` and restart Grove.
+
+## Worker Sandbox
+
+Workers run in isolated environments with multiple layers of protection.
+
+### Git Worktree Isolation
+
+Each worker gets a dedicated git worktree — a separate working directory on its own branch. Workers cannot access other repos or the main branch.
+
+### Guard Hooks
+
+Grove injects PreToolUse hooks into each worker's Claude Code session.
+
+**Bash Guard** blocks dangerous shell commands:
+- `git push`, `git reset --hard` — no direct remote operations
+- `rm -rf /`, `sudo` — no destructive system commands
+- Safe operations (git status, file reads, build commands) are allowed
+
+**Edit Boundary** restricts file writes:
+- `Write` and `Edit` tools are confined to the worktree directory
+- Temp directories (`/tmp/*`) are allowed
+- All other paths are blocked
+
+### CLAUDE.md Overlay
+
+Each worker receives a generated `.claude/CLAUDE.md` containing:
+- Task context (ID, title, description)
+- Step instructions and quality gate requirements
+- The repository's own CLAUDE.md content
+
+### No Remote Push
+
+Workers cannot push to remote repositories. The merge manager handles all push, PR creation, and merge operations after evaluation passes.
+
+## Network Security
+
+- The broker binds to a random ephemeral port (49152+) on localhost
+- Remote access requires the Cloudflare tunnel and auth token
+- All API endpoints require token authentication for remote requests
+- WebSocket connections require token for remote clients
+
+## File Permissions
+
+| File | Permissions | Contents |
+|------|-------------|----------|
+| `~/.grove/auth.token` | `0600` | Authentication token |
+| `~/.grove/grove.yaml` | User default | Configuration |
+| `~/.grove/grove.db` | User default | Task state |
+
+## Cost Controls
+
+Budgets prevent runaway spending:
+
+```yaml
+budgets:
+  per_task: 5.00      # Max per individual task
+  per_session: 10.00  # Max for one worker session
+  per_day: 25.00      # Daily ceiling
+  per_week: 100.00    # Weekly ceiling
+```
+
+The cost monitor enforces these limits and pauses work when thresholds are reached.


### PR DESCRIPTION
## Summary
- Full documentation set in `docs/`
  - **Getting Started**: installation, quick-start, upgrading
  - **Guides**: configuration reference, CLI reference, architecture, security
- README trimmed to concise overview with links to docs
- Updated version references to v0.1.1

## Structure
```
docs/
  getting-started/
    installation.md      — prerequisites, binary install, build from source
    quick-start.md       — init, add tree, grove up, first task
    upgrading.md         — grove upgrade, update checks, platforms
  guides/
    configuration.md     — grove.yaml full reference
    cli-reference.md     — all commands with examples
    architecture.md      — broker, orchestrator, workers, evaluator
    security.md          — auth, sandbox, guard hooks, cost controls
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)