### PR TITLE
fix: re-tag after amending release commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,10 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=v$version" >> "$GITHUB_OUTPUT"
 
+      - name: Re-tag after amend
+        run: |
+          git tag -f "v${{ steps.version.outputs.version }}"
+
       - name: Push commit and tag
         run: |
           git push origin main


### PR DESCRIPTION
## Problem
The v0.1.3 binary reports v0.1.2. Changelogen creates the git tag pointing at its commit, but we then amend that commit to include the synced `types.ts`. The tag still points at the pre-amend SHA, so the build job checks out code with the old GROVE_VERSION.

## Fix
Add `git tag -f` after the amend to move the tag to the new commit SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)