### PR TITLE
feat: notification system — Slack, system, and webhook channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Grove gives you a head agent (the orchestrator) that you chat with to plan work, decompose tasks across repos, and delegate to Claude Code workers — all observable through a web GUI accessible via secure tunnel.
 
-> **Status:** Alpha (v0.1.1). Core infrastructure works. Actively iterating.
+> **Status:** Alpha (![GitHub release](https://img.shields.io/github/v/release/bpamiri/grove?label=latest)). Core infrastructure works. Actively iterating.
 
 ## Quick Start
 
@@ -47,7 +47,7 @@ You --- Browser (GUI) --- Tunnel ---+
 
 The system separates **infrastructure** from **intelligence**:
 
-- **Broker** — Bun process managing HTTP+WebSocket server, SQLite state, tmux sessions, tunnel, health/cost monitoring, and merge queue. Stable, lightweight, never makes decisions.
+- **Broker** — Bun process managing HTTP+WebSocket server, SQLite state, tmux sessions, tunnel, health/cost monitoring, merge queue, and notifications. Stable, lightweight, never makes decisions.
 - **Orchestrator** — Persistent Claude Code session. You chat with it to plan and delegate.
 - **Workers** — Ephemeral Claude Code sessions in isolated git worktrees with sandboxed guard hooks.
 - **Evaluator** — Runs quality gates (tests, lint, diff size) on worker output. Separate agent because models are poor critics of their own output.
@@ -85,6 +85,7 @@ The system separates **infrastructure** from **intelligence**:
   - [Upgrading](docs/getting-started/upgrading.md)
 - **Guides**
   - [Configuration](docs/guides/configuration.md)
+  - [Notifications](docs/guides/configuration.md#notifications) — Slack, system, and webhook alerts
   - [CLI Reference](docs/guides/cli-reference.md)
   - [Architecture](docs/guides/architecture.md)
   - [Security](docs/guides/security.md)
@@ -93,7 +94,7 @@ The system separates **infrastructure** from **intelligence**:
 
 ```bash
 bun run dev -- help    # Run from source
-bun run test           # Run tests (96 tests)
+bun run test           # Run tests (121 tests)
 bun run build          # Build binary + frontend
 ```
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -184,6 +184,71 @@ settings:
 
 ---
 
+## Notifications
+
+Grove can send notifications when async events occur — task completions, failures, budget alerts, etc. Notifications are opt-in: if the `notifications` section is absent, nothing fires.
+
+```yaml
+notifications:
+  slack:
+    webhook_url: "https://hooks.slack.com/services/T00/B00/xxx"
+    events: [task_completed, task_failed, ci_failed]
+  system:
+    enabled: true
+    quiet_hours:
+      start: "22:00"
+      end: "07:00"
+    events: [task_completed, task_failed]
+  webhook:
+    url: "https://example.com/grove-events"
+    secret: "hmac-secret-here"
+    events: [task_completed, task_failed, pr_merged, budget_exceeded]
+```
+
+### Channels
+
+**Slack** — Posts to a Slack incoming webhook with Block Kit formatting and color-coded severity bars (green for success, red for failure, yellow for warnings).
+
+| Field | Description |
+|-------|-------------|
+| `webhook_url` | Slack incoming webhook URL. Required. |
+| `events` | List of event names to receive. Omit to receive all events. |
+
+**System** — Desktop notifications via macOS `osascript` or Linux `notify-send`. Suppressed during quiet hours.
+
+| Field | Description |
+|-------|-------------|
+| `enabled` | Set to `true` to activate. Required. |
+| `quiet_hours` | Optional `start`/`end` times (24-hour `"HH:MM"` format) during which notifications are suppressed. |
+| `events` | List of event names to receive. Omit to receive all events. |
+
+**Webhook** — Generic HTTP POST to any URL, with HMAC-SHA256 signature in the `X-Hub-Signature-256` header for payload verification.
+
+| Field | Description |
+|-------|-------------|
+| `url` | Webhook endpoint URL. Required. |
+| `secret` | Shared secret for HMAC-SHA256 signing. Required. |
+| `events` | List of event names to receive. Omit to receive all events. |
+
+### Notification Events
+
+| Event | Fires when |
+|-------|------------|
+| `task_completed` | A task finishes successfully. |
+| `task_failed` | A task fails. |
+| `gate_failed` | A quality gate (tests, lint, diff size) fails. |
+| `pr_merged` | A pull request is merged. |
+| `ci_failed` | CI fails on a pull request. |
+| `budget_warning` | Spend approaches a budget limit. |
+| `budget_exceeded` | Spend exceeds a budget limit. |
+| `orchestrator_crashed` | The orchestrator or a worker session crashes. |
+
+### Rate Limiting
+
+Notifications are rate-limited to **1 per event type per task per 60 seconds**. Different tasks completing within the same window each fire independently. Budget events (which have no task affiliation) are rate-limited globally.
+
+---
+
 ## Environment Variables
 
 | Variable | Default | Description |

--- a/src/broker/config.ts
+++ b/src/broker/config.ts
@@ -2,7 +2,7 @@
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { getEnv } from "./db";
-import type { GroveConfig, TreeConfig, PathConfig, BudgetConfig, SettingsConfig, ServerConfig, TunnelConfig, NormalizedPathConfig } from "../shared/types";
+import type { GroveConfig, TreeConfig, PathConfig, BudgetConfig, SettingsConfig, ServerConfig, TunnelConfig, NormalizedPathConfig, NotificationsConfig } from "../shared/types";
 import { normalizeAllPaths, stripPrompts } from "../engine/normalize";
 import { DEFAULT_PATHS, DEFAULT_BUDGETS, DEFAULT_SETTINGS } from "../shared/types";
 
@@ -115,6 +115,10 @@ export function tunnelConfig(): TunnelConfig {
   return loadConfig().tunnel ?? { provider: "cloudflare" as const, auth: "token" as const };
 }
 
+export function notificationsConfig(): NotificationsConfig | undefined {
+  return loadConfig().notifications;
+}
+
 export function workspaceName(): string {
   return loadConfig().workspace?.name || "Grove";
 }
@@ -133,5 +137,6 @@ function mergeDefaults(partial: Partial<GroveConfig>): GroveConfig {
     server: { ...DEFAULT_CONFIG.server, ...partial.server },
     tunnel: { ...DEFAULT_CONFIG.tunnel, ...partial.tunnel },
     settings: { ...DEFAULT_SETTINGS, ...partial.settings },
+    notifications: partial.notifications,
   };
 }

--- a/src/broker/index.ts
+++ b/src/broker/index.ts
@@ -16,6 +16,7 @@ import { CloudflareTunnel } from "../tunnel/cloudflare";
 import type { TunnelProvider } from "../tunnel/provider";
 import { generateSubdomain, generateSecret } from "./subdomain";
 import { registerGrove, startHeartbeat, stopHeartbeat, deregisterGrove } from "./registry";
+import { wireNotifications } from "../notifications/index";
 
 export interface BrokerInfo {
   pid: number;
@@ -102,6 +103,9 @@ export async function startBroker(): Promise<BrokerInfo> {
     },
   });
   startCostMonitor({ db, budgets: config.budgets });
+
+  // Wire notification channels (opt-in via grove.yaml)
+  wireNotifications();
 
   // Spawn orchestrator
   orchestrator.spawn(db, GROVE_LOG_DIR);

--- a/src/notifications/channels/slack.ts
+++ b/src/notifications/channels/slack.ts
@@ -1,0 +1,45 @@
+// Grove v3 — Slack notification channel (webhook + Block Kit)
+import type { SlackChannelConfig } from "../../shared/types";
+import type { NotificationChannel, NotificationEvent } from "../types";
+
+const COLORS: Record<string, string> = {
+  task_completed: "#2eb67d",   // green
+  task_failed: "#e01e5a",      // red
+  gate_failed: "#e01e5a",
+  ci_failed: "#e01e5a",
+  pr_merged: "#2eb67d",
+  budget_warning: "#ecb22e",   // yellow
+  budget_exceeded: "#e01e5a",
+  orchestrator_crashed: "#e01e5a",
+};
+
+export function buildSlackPayload(event: NotificationEvent): object {
+  return {
+    text: `${event.title}: ${event.body}`,
+    attachments: [
+      {
+        color: COLORS[event.name] ?? "#36a64f",
+        blocks: [
+          { type: "header", text: { type: "plain_text", text: event.title, emoji: false } },
+          { type: "section", text: { type: "mrkdwn", text: event.body } },
+        ],
+      },
+    ],
+  };
+}
+
+export function createSlackChannel(config: SlackChannelConfig): NotificationChannel {
+  return {
+    name: "slack",
+    events: config.events,
+    async send(event: NotificationEvent): Promise<void> {
+      const payload = buildSlackPayload(event);
+      const res = await fetch(config.webhook_url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error(`Slack webhook returned ${res.status}`);
+    },
+  };
+}

--- a/src/notifications/channels/system.ts
+++ b/src/notifications/channels/system.ts
@@ -1,0 +1,38 @@
+// Grove v3 — System notification channel (macOS osascript / Linux notify-send)
+import type { SystemChannelConfig } from "../../shared/types";
+import type { NotificationChannel, NotificationEvent } from "../types";
+
+export function parseHour(time: string): number {
+  const [h] = time.split(":");
+  return parseInt(h, 10);
+}
+
+export function isQuietHours(quietHours: SystemChannelConfig["quiet_hours"], nowHour?: number): boolean {
+  if (!quietHours) return false;
+  const h = nowHour ?? new Date().getHours();
+  const start = parseHour(quietHours.start);
+  const end = parseHour(quietHours.end);
+  // Wraps midnight: e.g. start=22, end=7 means 22-23 and 0-6
+  return start > end ? (h >= start || h < end) : (h >= start && h < end);
+}
+
+export function createSystemChannel(config: SystemChannelConfig): NotificationChannel {
+  return {
+    name: "system",
+    events: config.events,
+    async send(event: NotificationEvent): Promise<void> {
+      if (!config.enabled) return;
+      if (isQuietHours(config.quiet_hours)) return;
+
+      const escape = (s: string) => s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+      const title = escape(event.title);
+      const body = escape(event.body);
+
+      if (process.platform === "darwin") {
+        Bun.spawnSync(["osascript", "-e", `display notification "${body}" with title "${title}"`]);
+      } else {
+        Bun.spawnSync(["notify-send", title, body]);
+      }
+    },
+  };
+}

--- a/src/notifications/channels/webhook.ts
+++ b/src/notifications/channels/webhook.ts
@@ -1,0 +1,37 @@
+// Grove v3 — Generic webhook notification channel with HMAC-SHA256 signing
+import type { WebhookChannelConfig } from "../../shared/types";
+import type { NotificationChannel, NotificationEvent } from "../types";
+
+export async function signPayload(secret: string, body: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body));
+  return Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export function createWebhookChannel(config: WebhookChannelConfig): NotificationChannel {
+  return {
+    name: "webhook",
+    events: config.events,
+    async send(event: NotificationEvent): Promise<void> {
+      const payload = JSON.stringify(event);
+      const sig = await signPayload(config.secret, payload);
+      const res = await fetch(config.url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Hub-Signature-256": `sha256=${sig}`,
+        },
+        body: payload,
+      });
+      if (!res.ok) throw new Error(`Webhook returned ${res.status}`);
+    },
+  };
+}

--- a/src/notifications/dispatcher.ts
+++ b/src/notifications/dispatcher.ts
@@ -1,0 +1,40 @@
+// Grove v3 — Notification dispatcher with rate limiting
+import type { NotificationEventName } from "../shared/types";
+import type { NotificationChannel, NotificationEvent } from "./types";
+
+// Rate limit: "eventName:taskId" → last-sent epoch ms
+const _sent = new Map<string, number>();
+const RATE_MS = 60_000;
+
+function rateLimitKey(event: NotificationEventName, taskId: string | null): string {
+  return `${event}:${taskId ?? "_"}`;
+}
+
+function isRateLimited(event: NotificationEventName, taskId: string | null): boolean {
+  const last = _sent.get(rateLimitKey(event, taskId)) ?? 0;
+  return Date.now() - last < RATE_MS;
+}
+
+function markSent(event: NotificationEventName, taskId: string | null): void {
+  _sent.set(rateLimitKey(event, taskId), Date.now());
+}
+
+function wantsEvent(channel: NotificationChannel, event: NotificationEventName): boolean {
+  return !channel.events || channel.events.includes(event);
+}
+
+export function dispatch(channels: NotificationChannel[], event: NotificationEvent): void {
+  if (isRateLimited(event.name, event.taskId)) return;
+  markSent(event.name, event.taskId);
+
+  for (const channel of channels) {
+    if (!wantsEvent(channel, event.name)) continue;
+    channel.send(event).catch((err) => {
+      console.error(`[notify:${channel.name}]`, err);
+    });
+  }
+}
+
+export function resetRateLimiter(): void {
+  _sent.clear();
+}

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -1,0 +1,66 @@
+// Grove v3 — Notification event bus wiring
+import { bus } from "../broker/event-bus";
+import { notificationsConfig } from "../broker/config";
+import type { NotificationEvent } from "./types";
+import type { NotificationEventName } from "../shared/types";
+import { dispatch } from "./dispatcher";
+import { createSlackChannel } from "./channels/slack";
+import { createSystemChannel } from "./channels/system";
+import { createWebhookChannel } from "./channels/webhook";
+
+let _wired = false;
+
+function buildEvent(name: NotificationEventName, taskId: string | null, title: string, body: string): NotificationEvent {
+  return { name, taskId, title, body, timestamp: Date.now() };
+}
+
+export function wireNotifications(): void {
+  if (_wired) return;
+  _wired = true;
+
+  const cfg = notificationsConfig();
+  if (!cfg) return;
+
+  // Build active channels from config
+  const channels: NotificationChannel[] = [];
+  if (cfg.slack?.webhook_url) channels.push(createSlackChannel(cfg.slack));
+  if (cfg.system?.enabled) channels.push(createSystemChannel(cfg.system));
+  if (cfg.webhook?.url && cfg.webhook?.secret) channels.push(createWebhookChannel(cfg.webhook));
+
+  if (channels.length === 0) return;
+
+  bus.on("task:status", ({ taskId, status }) => {
+    if (status === "completed") {
+      dispatch(channels, buildEvent("task_completed", taskId, "Task Completed", `Task ${taskId} completed successfully`));
+    }
+    if (status === "failed") {
+      dispatch(channels, buildEvent("task_failed", taskId, "Task Failed", `Task ${taskId} failed`));
+    }
+  });
+
+  bus.on("gate:result", ({ taskId, gate, passed, message }) => {
+    if (!passed) {
+      dispatch(channels, buildEvent("gate_failed", taskId, "Gate Failed", `Task ${taskId}: ${gate} — ${message}`));
+    }
+  });
+
+  bus.on("merge:completed", ({ taskId, prNumber }) => {
+    dispatch(channels, buildEvent("pr_merged", taskId, "PR Merged", `Task ${taskId}: PR #${prNumber} merged`));
+  });
+
+  bus.on("merge:ci_failed", ({ taskId, prNumber }) => {
+    dispatch(channels, buildEvent("ci_failed", taskId, "CI Failed", `Task ${taskId}: CI failed on PR #${prNumber}`));
+  });
+
+  bus.on("cost:budget_warning", ({ current, limit, period }) => {
+    dispatch(channels, buildEvent("budget_warning", null, "Budget Warning", `${period}: $${current.toFixed(2)} of $${limit.toFixed(2)} limit`));
+  });
+
+  bus.on("cost:budget_exceeded", ({ current, limit, period }) => {
+    dispatch(channels, buildEvent("budget_exceeded", null, "Budget Exceeded", `${period}: $${current.toFixed(2)} exceeded $${limit.toFixed(2)} limit`));
+  });
+
+  bus.on("monitor:crash", ({ taskId, sessionId }) => {
+    dispatch(channels, buildEvent("orchestrator_crashed", taskId, "Orchestrator Crashed", `Session ${sessionId} crashed for task ${taskId}`));
+  });
+}

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -1,0 +1,16 @@
+// Grove v3 — Notification system types
+import type { NotificationEventName } from "../shared/types";
+
+export interface NotificationEvent {
+  name: NotificationEventName;
+  taskId: string | null;
+  title: string;
+  body: string;
+  timestamp: number;
+}
+
+export interface NotificationChannel {
+  name: string;
+  events?: NotificationEventName[];  // if unset, receives all events
+  send(event: NotificationEvent): Promise<void>;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -199,6 +199,39 @@ export interface SettingsConfig {
   quality_gates?: QualityGatesConfig;
 }
 
+export type NotificationEventName =
+  | "task_completed"
+  | "task_failed"
+  | "gate_failed"
+  | "pr_merged"
+  | "ci_failed"
+  | "budget_warning"
+  | "budget_exceeded"
+  | "orchestrator_crashed";
+
+export interface SlackChannelConfig {
+  webhook_url: string;
+  events?: NotificationEventName[];
+}
+
+export interface SystemChannelConfig {
+  enabled: boolean;
+  quiet_hours?: { start: string; end: string }; // "HH:MM" format, e.g. "22:00"
+  events?: NotificationEventName[];
+}
+
+export interface WebhookChannelConfig {
+  url: string;
+  secret: string;
+  events?: NotificationEventName[];
+}
+
+export interface NotificationsConfig {
+  slack?: SlackChannelConfig;
+  system?: SystemChannelConfig;
+  webhook?: WebhookChannelConfig;
+}
+
 export interface GroveConfig {
   workspace: { name: string };
   trees: Record<string, TreeConfig>;
@@ -207,6 +240,7 @@ export interface GroveConfig {
   server: ServerConfig;
   tunnel: TunnelConfig;
   settings: SettingsConfig;
+  notifications?: NotificationsConfig;
 }
 
 export interface QualityGatesConfig {

--- a/tests/notifications/dispatcher.test.ts
+++ b/tests/notifications/dispatcher.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { dispatch, resetRateLimiter } from "../../src/notifications/dispatcher";
+import type { NotificationChannel, NotificationEvent } from "../../src/notifications/types";
+
+function makeEvent(overrides: Partial<NotificationEvent> = {}): NotificationEvent {
+  return {
+    name: "task_completed",
+    taskId: "W-001",
+    title: "Task Completed",
+    body: "Task W-001 completed",
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeChannel(name: string): NotificationChannel & { calls: NotificationEvent[] } {
+  const calls: NotificationEvent[] = [];
+  return {
+    name,
+    calls,
+    async send(event: NotificationEvent) {
+      calls.push(event);
+    },
+  };
+}
+
+describe("dispatch", () => {
+  beforeEach(() => {
+    resetRateLimiter();
+  });
+
+  test("dispatches to all channels", () => {
+    const slack = makeChannel("slack");
+    const system = makeChannel("system");
+    const event = makeEvent();
+
+    dispatch([slack, system], event);
+    expect(slack.calls).toHaveLength(1);
+    expect(system.calls).toHaveLength(1);
+    expect(slack.calls[0].name).toBe("task_completed");
+  });
+
+  test("rate limits same event+task within 60s", () => {
+    const ch = makeChannel("slack");
+
+    dispatch([ch], makeEvent());
+    dispatch([ch], makeEvent());
+    dispatch([ch], makeEvent());
+
+    expect(ch.calls).toHaveLength(1);
+  });
+
+  test("allows same event type for different tasks", () => {
+    const ch = makeChannel("slack");
+
+    dispatch([ch], makeEvent({ taskId: "W-001" }));
+    dispatch([ch], makeEvent({ taskId: "W-002" }));
+
+    expect(ch.calls).toHaveLength(2);
+  });
+
+  test("allows different event types for same task", () => {
+    const ch = makeChannel("slack");
+
+    dispatch([ch], makeEvent({ name: "task_completed" }));
+    dispatch([ch], makeEvent({ name: "task_failed" }));
+
+    expect(ch.calls).toHaveLength(2);
+  });
+
+  test("rate limits null taskId events globally", () => {
+    const ch = makeChannel("slack");
+
+    dispatch([ch], makeEvent({ name: "budget_warning", taskId: null }));
+    dispatch([ch], makeEvent({ name: "budget_warning", taskId: null }));
+
+    expect(ch.calls).toHaveLength(1);
+  });
+
+  test("channel errors are caught and do not propagate", () => {
+    const failCh: NotificationChannel = {
+      name: "slack",
+      async send() {
+        throw new Error("network error");
+      },
+    };
+    const goodCh = makeChannel("webhook");
+
+    // Should not throw
+    dispatch([failCh, goodCh], makeEvent());
+    expect(goodCh.calls).toHaveLength(1);
+  });
+});

--- a/tests/notifications/slack.test.ts
+++ b/tests/notifications/slack.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { buildSlackPayload, createSlackChannel } from "../../src/notifications/channels/slack";
+import type { NotificationEvent } from "../../src/notifications/types";
+
+const originalFetch = globalThis.fetch;
+
+function makeEvent(overrides: Partial<NotificationEvent> = {}): NotificationEvent {
+  return {
+    name: "task_completed",
+    taskId: "W-001",
+    title: "Task Completed",
+    body: "Task W-001 completed successfully",
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("buildSlackPayload", () => {
+  test("includes text fallback and attachment with color", () => {
+    const payload = buildSlackPayload(makeEvent()) as any;
+
+    expect(payload.text).toContain("Task Completed");
+    expect(payload.attachments).toHaveLength(1);
+    expect(payload.attachments[0].color).toBe("#2eb67d"); // green for completed
+    expect(payload.attachments[0].blocks).toHaveLength(2);
+    expect(payload.attachments[0].blocks[0].type).toBe("header");
+    expect(payload.attachments[0].blocks[1].type).toBe("section");
+  });
+
+  test("uses red for failure events", () => {
+    const payload = buildSlackPayload(makeEvent({ name: "task_failed" })) as any;
+    expect(payload.attachments[0].color).toBe("#e01e5a");
+  });
+
+  test("uses yellow for budget warning", () => {
+    const payload = buildSlackPayload(makeEvent({ name: "budget_warning" })) as any;
+    expect(payload.attachments[0].color).toBe("#ecb22e");
+  });
+});
+
+describe("createSlackChannel", () => {
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("posts payload to webhook URL", async () => {
+    let capturedUrl = "";
+    let capturedBody = "";
+
+    globalThis.fetch = async (input: any, init: any) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      capturedBody = init?.body;
+      return new Response("ok");
+    };
+
+    const ch = createSlackChannel({ webhook_url: "https://hooks.slack.com/test" });
+    await ch.send(makeEvent());
+
+    expect(capturedUrl).toBe("https://hooks.slack.com/test");
+    const body = JSON.parse(capturedBody);
+    expect(body.text).toContain("Task Completed");
+    expect(body.attachments[0].color).toBe("#2eb67d");
+  });
+
+  test("throws on non-ok response", async () => {
+    globalThis.fetch = async () => new Response("error", { status: 500 });
+
+    const ch = createSlackChannel({ webhook_url: "https://hooks.slack.com/test" });
+    await expect(ch.send(makeEvent())).rejects.toThrow("Slack webhook returned 500");
+  });
+});

--- a/tests/notifications/system.test.ts
+++ b/tests/notifications/system.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from "bun:test";
+import { isQuietHours, parseHour } from "../../src/notifications/channels/system";
+
+describe("parseHour", () => {
+  test("parses HH:MM to hour number", () => {
+    expect(parseHour("22:00")).toBe(22);
+    expect(parseHour("07:30")).toBe(7);
+    expect(parseHour("0:00")).toBe(0);
+  });
+});
+
+describe("isQuietHours", () => {
+  test("returns false when no quiet hours configured", () => {
+    expect(isQuietHours(undefined)).toBe(false);
+  });
+
+  test("same-day range: within quiet hours", () => {
+    // 9:00 to 17:00, current hour = 12
+    expect(isQuietHours({ start: "09:00", end: "17:00" }, 12)).toBe(true);
+  });
+
+  test("same-day range: outside quiet hours", () => {
+    expect(isQuietHours({ start: "09:00", end: "17:00" }, 20)).toBe(false);
+  });
+
+  test("midnight-crossing range: within quiet hours (late night)", () => {
+    // 22:00 to 07:00, current hour = 23
+    expect(isQuietHours({ start: "22:00", end: "07:00" }, 23)).toBe(true);
+  });
+
+  test("midnight-crossing range: within quiet hours (early morning)", () => {
+    expect(isQuietHours({ start: "22:00", end: "07:00" }, 3)).toBe(true);
+  });
+
+  test("midnight-crossing range: outside quiet hours", () => {
+    expect(isQuietHours({ start: "22:00", end: "07:00" }, 12)).toBe(false);
+  });
+
+  test("boundary: at start hour is quiet", () => {
+    expect(isQuietHours({ start: "22:00", end: "07:00" }, 22)).toBe(true);
+  });
+
+  test("boundary: at end hour is not quiet", () => {
+    expect(isQuietHours({ start: "22:00", end: "07:00" }, 7)).toBe(false);
+  });
+});

--- a/tests/notifications/webhook.test.ts
+++ b/tests/notifications/webhook.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { signPayload, createWebhookChannel } from "../../src/notifications/channels/webhook";
+import type { NotificationEvent } from "../../src/notifications/types";
+
+const originalFetch = globalThis.fetch;
+
+function makeEvent(overrides: Partial<NotificationEvent> = {}): NotificationEvent {
+  return {
+    name: "task_completed",
+    taskId: "W-001",
+    title: "Task Completed",
+    body: "Task W-001 completed",
+    timestamp: 1700000000000,
+    ...overrides,
+  };
+}
+
+describe("signPayload", () => {
+  test("produces consistent HMAC-SHA256 hex digest", async () => {
+    const sig1 = await signPayload("secret", "hello");
+    const sig2 = await signPayload("secret", "hello");
+    expect(sig1).toBe(sig2);
+    expect(sig1).toMatch(/^[0-9a-f]{64}$/); // SHA-256 = 32 bytes = 64 hex chars
+  });
+
+  test("different secrets produce different signatures", async () => {
+    const sig1 = await signPayload("secret-a", "hello");
+    const sig2 = await signPayload("secret-b", "hello");
+    expect(sig1).not.toBe(sig2);
+  });
+
+  test("different payloads produce different signatures", async () => {
+    const sig1 = await signPayload("secret", "hello");
+    const sig2 = await signPayload("secret", "world");
+    expect(sig1).not.toBe(sig2);
+  });
+});
+
+describe("createWebhookChannel", () => {
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("sends JSON with HMAC signature header", async () => {
+    let capturedHeaders: Record<string, string> = {};
+    let capturedBody = "";
+
+    globalThis.fetch = async (_input: any, init: any) => {
+      capturedHeaders = Object.fromEntries(new Headers(init.headers).entries());
+      capturedBody = init?.body;
+      return new Response("ok");
+    };
+
+    const ch = createWebhookChannel({ url: "https://example.com/hook", secret: "test-secret" });
+    await ch.send(makeEvent());
+
+    expect(capturedHeaders["content-type"]).toBe("application/json");
+    expect(capturedHeaders["x-hub-signature-256"]).toMatch(/^sha256=[0-9a-f]{64}$/);
+
+    // Verify signature matches the body
+    const expectedSig = await signPayload("test-secret", capturedBody);
+    expect(capturedHeaders["x-hub-signature-256"]).toBe(`sha256=${expectedSig}`);
+  });
+
+  test("throws on non-ok response", async () => {
+    globalThis.fetch = async () => new Response("error", { status: 403 });
+
+    const ch = createWebhookChannel({ url: "https://example.com/hook", secret: "s" });
+    await expect(ch.send(makeEvent())).rejects.toThrow("Webhook returned 403");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds pluggable notification system with 3 channels: Slack (webhook + Block Kit), system (osascript/notify-send + quiet hours), and generic webhook (HMAC-SHA256 signed)
- Subscribes to 8 event bus events: task_completed, task_failed, gate_failed, pr_merged, ci_failed, budget_warning, budget_exceeded, orchestrator_crashed
- Opt-in via `grove.yaml` `notifications` section — no notifications if section absent
- Rate-limited: max 1 per event type per task per 60 seconds

### New files
| File | Purpose |
|------|---------|
| `src/notifications/types.ts` | `NotificationEvent` and `NotificationChannel` interfaces |
| `src/notifications/dispatcher.ts` | Rate-limited dispatch to channels |
| `src/notifications/channels/slack.ts` | Slack webhook with Block Kit, color-coded severity |
| `src/notifications/channels/system.ts` | macOS/Linux desktop notifications with quiet hours |
| `src/notifications/channels/webhook.ts` | Generic webhook with HMAC-SHA256 signing |
| `src/notifications/index.ts` | Event bus wiring |
| `tests/notifications/*.test.ts` | 25 tests covering dispatcher, Slack, system, webhook |

### Modified files
- `src/shared/types.ts` — notification config types + `GroveConfig.notifications`
- `src/broker/config.ts` — `notificationsConfig()` accessor
- `src/broker/index.ts` — `wireNotifications()` call at startup
- `docs/guides/configuration.md` — full Notifications section
- `README.md` — dynamic version badge, notifications mention, test count update

Closes #38

## Test plan

- [x] All 25 new notification tests pass
- [x] Full suite (121 tests) passes — purely additive, no regressions
- [ ] Manual: add `notifications.slack.webhook_url` to grove.yaml, start broker, complete a task, verify Slack message
- [ ] Manual: enable `notifications.system`, verify desktop notification on macOS
- [ ] Manual: configure webhook with secret, verify `X-Hub-Signature-256` header matches HMAC of body

🤖 Generated with [Claude Code](https://claude.com/claude-code)