### PR TITLE
feat: show grove version in CLI status, API, and web sidebar

### DIFF
--- a/src/broker/server.ts
+++ b/src/broker/server.ts
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import { join, extname } from "node:path";
 import type { Database } from "./db";
 import { bus } from "./event-bus";
-import type { EventBusMap } from "../shared/types";
+import { GROVE_VERSION, type EventBusMap } from "../shared/types";
 import { EMBEDDED_ASSETS } from "./web-assets.generated";
 import { startSeedSession, sendSeedMessage, stopSeedSession, isSeedSessionActive, setSeedBroadcast } from "./seed-session";
 
@@ -312,6 +312,7 @@ async function handleApi(
       const { queueLength } = await import("./dispatch");
       const { isSpawningPaused } = await import("../monitor/cost");
       return json({
+        version: GROVE_VERSION,
         broker: "running",
         remoteUrl: _remoteUrl,
         orchestrator: isRunning() ? "running" : "stopped",

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -2,6 +2,7 @@
 import pc from "picocolors";
 import { readBrokerInfo } from "../../broker/index";
 import { isAlive } from "../../agents/stream-parser";
+import { GROVE_VERSION } from "../../shared/types";
 
 export async function run(_args: string[]) {
   const info = readBrokerInfo();
@@ -13,7 +14,7 @@ export async function run(_args: string[]) {
 
   const brokerAlive = isAlive(info.pid);
 
-  console.log(`${pc.bold(pc.green("Grove Status"))}`);
+  console.log(`${pc.bold(pc.green("Grove Status"))} ${pc.dim(`v${GROVE_VERSION}`)}`);
   console.log();
   console.log(`  Broker:  ${brokerAlive ? pc.green("running") : pc.red("dead")} (PID ${info.pid})`);
   console.log(`  URL:     ${pc.bold(info.url)}`);

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -97,6 +97,7 @@ export default function Sidebar({ trees, status, taskCount, selectedTree, onSele
           </div>
           <span>Workers {status?.workers ?? 0}</span>
           <span>Today ${(status?.cost.today ?? 0).toFixed(2)}</span>
+          {status?.version && <span className="text-zinc-600">v{status.version}</span>}
         </div>
         {status?.remoteUrl && (
           <a

--- a/web/src/hooks/useTasks.ts
+++ b/web/src/hooks/useTasks.ts
@@ -43,6 +43,7 @@ export interface Tree {
 }
 
 export interface Status {
+  version?: string;
   broker: string;
   remoteUrl: string | null;
   orchestrator: string;


### PR DESCRIPTION
## Summary

- Add `GROVE_VERSION` to `grove status` CLI header
- Add `version` field to `/api/status` JSON response
- Show version in web sidebar status bar (reads from running broker)

## Test plan

- [x] `tsc --noEmit` — clean
- [x] 238/238 tests pass
- [ ] Run `grove status` — verify version appears in header
- [ ] Check web GUI sidebar — verify version in status bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)