### PR TITLE
feat: show version in grove up output

### DIFF
--- a/src/cli/commands/up.ts
+++ b/src/cli/commands/up.ts
@@ -3,6 +3,7 @@ import pc from "picocolors";
 import { startBroker, readBrokerInfo } from "../../broker/index";
 import { getOrCreateToken } from "../../broker/auth";
 import { checkForUpdate } from "../update-check";
+import { GROVE_VERSION } from "../../shared/types";
 
 export async function run(_args: string[]) {
   // Check if already running
@@ -14,7 +15,7 @@ export async function run(_args: string[]) {
     return;
   }
 
-  console.log(`${pc.green("Starting Grove...")}`)
+  console.log(`${pc.green("Starting Grove")} ${pc.dim(`v${GROVE_VERSION}`)}`)
 
   try {
     const info = await startBroker();


### PR DESCRIPTION
## Summary

- Display `GROVE_VERSION` in the `grove up` startup message: `Starting Grove v0.1.8`

## Test plan

- [ ] Run `grove up` — verify version appears in startup line

🤖 Generated with [Claude Code](https://claude.com/claude-code)