### PR TITLE
feat: (W-023) Seeding: auto-populate task description as initial prompt

### DIFF
--- a/src/broker/seed-session.ts
+++ b/src/broker/seed-session.ts
@@ -27,6 +27,8 @@ interface SeedSession {
   pid: number | null;
   stopPoller: () => void;
   conversation: ConversationMessage[];
+  /** When set, auto-sent as the first user message once Claude is idle */
+  pendingDescription?: string;
 }
 
 type BroadcastFn = (type: string, data: any) => void;
@@ -111,6 +113,7 @@ export function startSeedSession(
     pid,
     stopPoller,
     conversation: [],
+    pendingDescription: task.description || undefined,
   };
 
   sessions.set(taskId, session);
@@ -134,7 +137,7 @@ export function sendSeedMessage(taskId: string, text: string, db: Database): boo
   // Broadcast user message
   broadcast("seed:message", {
     taskId,
-    role: "user",
+    source: "user",
     content: text,
   });
 
@@ -234,6 +237,17 @@ function startPoller(taskId: string, target: string, db: Database): () => void {
       try {
         const content = tmux.capturePane(target, 500);
 
+        // Auto-send pending description once Claude shows its idle prompt
+        const session = sessions.get(taskId);
+        if (session?.pendingDescription) {
+          const lastNonEmpty = content.split("\n").filter(l => l.trim()).pop()?.trim();
+          if (lastNonEmpty === "❯" || lastNonEmpty === "❯ ") {
+            const desc = session.pendingDescription;
+            session.pendingDescription = undefined;
+            sendSeedMessage(taskId, desc, db);
+          }
+        }
+
         // Scan for structured JSON events first
         scanForJsonEvents(taskId, content, db);
 
@@ -264,7 +278,7 @@ function startPoller(taskId: string, target: string, db: Database): () => void {
 
             broadcast("seed:message", {
               taskId,
-              role: "assistant",
+              source: "ai",
               content: text,
             });
           }
@@ -328,7 +342,7 @@ function handleSeedEvent(taskId: string, event: any, db: Database): void {
       }
       broadcast("seed:message", {
         taskId,
-        role: "assistant",
+        source: "ai",
         content: "",
         html: event.html,
       });

--- a/src/broker/server.ts
+++ b/src/broker/server.ts
@@ -684,10 +684,16 @@ async function handleApi(
     if (seedGetMatch && req.method === "GET") {
       const seed = db.seedGet(seedGetMatch[1]);
       if (!seed) return json(null);
+      // Map internal role field to frontend source field
+      const conv = seed.conversation ? JSON.parse(seed.conversation) : [];
       return json({
         ...seed,
         active: isSeedSessionActive(seedGetMatch[1]),
-        conversation: seed.conversation ? JSON.parse(seed.conversation) : [],
+        conversation: conv.map((m: any) => ({
+          source: m.source ?? (m.role === "assistant" ? "ai" : "user"),
+          content: m.content,
+          ...(m.html ? { html: m.html } : {}),
+        })),
       });
     }
 


### PR DESCRIPTION
## Seeding: auto-populate task description as initial prompt

When task has a description, use it as the first message in the seeding chat instead of starting blank. GitHub issue: bpamiri/grove#19

**Task:** W-023
**Path:** development
**Cost:** $0.00
**Files changed:** 7

### Quality Gates
- commits: passed — 1 commit on branch
- tests: passed — No test command configured — skipped
- diff_size: passed — 28 lines changed

Closes #19

---
*Created by [Grove](https://grove.cloud)*