### PR TITLE
feat: (W-029) Auto-create GitHub issues when tasks are created in Grove...

### DIFF
--- a/docs/superpowers/specs/2026-03-30-github-issue-sync-design.md
+++ b/docs/superpowers/specs/2026-03-30-github-issue-sync-design.md
@@ -1,0 +1,84 @@
+# Design: Auto-Create GitHub Issues on Task Creation
+
+**Task:** W-029 | **Issue:** #57 | **Date:** 2026-03-30
+
+## Problem
+
+Tasks created in Grove (GUI, orchestrator, API) have no corresponding GitHub issue.
+This means `github_issue` is NULL, auto-close on merge doesn't fire, and work isn't
+visible in GitHub's issue tracker.
+
+## Solution
+
+Listen for `task:created` events on the bus. When a task has a `tree_id` pointing to
+a tree with `github` configured, call `gh issue create` and store the issue number.
+
+## Architecture
+
+### New function: `ghIssueCreate()` in `src/merge/github.ts`
+
+```typescript
+export function ghIssueCreate(repo: string, opts: {
+  title: string;
+  body: string;
+}): { number: number; url: string }
+```
+
+Calls `gh issue create -R <repo> --title <title> --body <body>`, parses the returned
+URL for the issue number.
+
+### New module: `src/broker/github-sync.ts`
+
+Exports `wireGitHubSync(db: Database): void`, called from broker startup.
+
+Listens to `bus.on("task:created")` and:
+1. Skips if `task.github_issue` is already set (imported issues)
+2. Skips if `task.tree_id` is null (no tree yet)
+3. Looks up tree — skips if `tree.github` is null
+4. Calls `ghIssueCreate(tree.github, { title, body })`
+5. Updates `tasks.github_issue = issueNumber`
+6. Logs `issue_created` event
+7. On failure: logs `issue_create_failed` event (non-fatal)
+
+### Deferred creation at dispatch
+
+For tasks created without a `tree_id`, issue creation is attempted at dispatch time
+(`POST /api/tasks/:id/dispatch`). Before promoting to `queued`, if `github_issue` is
+null and tree has `github`, create the issue.
+
+### Issue body format
+
+```
+## {task.title}
+
+{task.description || "No description provided."}
+
+**Task:** {task.id}
+**Path:** {task.path_name}
+
+*Created by [Grove](https://grove.cloud)*
+```
+
+## Event types
+
+Add to `EventType` enum:
+- `IssueCreated = "issue_created"`
+- `IssueCreateFailed = "issue_create_failed"`
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `src/merge/github.ts` | Add `ghIssueCreate()` |
+| `src/broker/github-sync.ts` | New — event listener module |
+| `src/broker/index.ts` | Wire `wireGitHubSync(db)` at startup |
+| `src/broker/server.ts` | Add deferred issue creation at dispatch |
+| `src/shared/types.ts` | Add event type enums |
+| `tests/merge/github.test.ts` | Test `ghIssueCreate()` |
+| `tests/broker/github-sync.test.ts` | New — test the event handler |
+
+## Non-goals
+
+- No backfill of existing tasks
+- No settings toggle (gated on `tree.github` being non-null)
+- No label assignment on created issues

--- a/src/broker/github-sync.ts
+++ b/src/broker/github-sync.ts
@@ -1,0 +1,58 @@
+// Grove v3 — Auto-create GitHub issues when tasks are created
+import { bus } from "./event-bus";
+import type { Database } from "./db";
+
+/** Format the GitHub issue body for a Grove task */
+export function formatIssueBody(task: { id: string; description: string | null; path_name: string }): string {
+  const desc = task.description || "No description provided.";
+  return [
+    desc,
+    "",
+    `**Task:** ${task.id}`,
+    `**Path:** ${task.path_name}`,
+    "",
+    "*Created by [Grove](https://grove.cloud)*",
+  ].join("\n");
+}
+
+/**
+ * Attempt to create a GitHub issue for a task.
+ * Returns the issue number on success, or null if skipped/failed.
+ */
+export function createIssueForTask(
+  db: Database,
+  taskId: string,
+  ghIssueCreate: (repo: string, opts: { title: string; body: string }) => { number: number; url: string },
+): number | null {
+  const task = db.taskGet(taskId);
+  if (!task) return null;
+
+  // Skip if already has an issue (e.g. imported from GitHub)
+  if (task.github_issue) return null;
+
+  // Skip if no tree assigned
+  if (!task.tree_id) return null;
+
+  const tree = db.treeGet(task.tree_id);
+  if (!tree || !tree.github) return null;
+
+  try {
+    const body = formatIssueBody(task);
+    const { number } = ghIssueCreate(tree.github, { title: task.title, body });
+    db.run("UPDATE tasks SET github_issue = ? WHERE id = ?", [number, task.id]);
+    db.addEvent(task.id, null, "issue_created", `GitHub issue #${number} created on ${tree.github}`);
+    return number;
+  } catch (err: any) {
+    db.addEvent(task.id, null, "issue_create_failed", `Failed to create GitHub issue: ${err.message}`);
+    return null;
+  }
+}
+
+/** Wire the event listener — call once at broker startup */
+export function wireGitHubSync(db: Database): void {
+  const { ghIssueCreate } = require("../merge/github");
+
+  bus.on("task:created", ({ task }) => {
+    createIssueForTask(db, task.id, ghIssueCreate);
+  });
+}

--- a/src/broker/index.ts
+++ b/src/broker/index.ts
@@ -16,6 +16,7 @@ import type { TunnelProvider } from "../tunnel/provider";
 import { generateSubdomain, generateSecret } from "./subdomain";
 import { registerGrove, startHeartbeat, stopHeartbeat, deregisterGrove } from "./registry";
 import { wireNotifications } from "../notifications/index";
+import { wireGitHubSync } from "./github-sync";
 
 export interface BrokerInfo {
   pid: number;
@@ -96,6 +97,9 @@ export async function startBroker(): Promise<BrokerInfo> {
 
   // Wire notification channels (opt-in via grove.yaml)
   wireNotifications();
+
+  // Wire GitHub issue auto-creation on task creation
+  wireGitHubSync(db);
 
   // Initialize orchestrator
   orchestrator.init(db);

--- a/src/broker/server.ts
+++ b/src/broker/server.ts
@@ -486,6 +486,14 @@ async function handleApi(
       const taskId = dispatchMatch[1];
       const task = db.taskGet(taskId);
       if (!task) return json({ error: "Task not found" }, 404);
+
+      // Deferred GitHub issue creation: if task has a tree but no issue yet, create one now
+      if (!task.github_issue && task.tree_id) {
+        const { createIssueForTask } = await import("./github-sync");
+        const { ghIssueCreate } = await import("../merge/github");
+        createIssueForTask(db, taskId, ghIssueCreate);
+      }
+
       const { configNormalizedPaths } = await import("./config");
       const paths = configNormalizedPaths();
       const pathConfig = paths[task.path_name];

--- a/src/merge/github.ts
+++ b/src/merge/github.ts
@@ -155,6 +155,25 @@ export interface GhIssue {
   labels: Array<{ name: string }>;
 }
 
+export function ghIssueCreate(repo: string, opts: {
+  title: string;
+  body: string;
+}): { number: number; url: string } {
+  const args = [
+    "issue", "create", "-R", repo,
+    "--title", opts.title,
+    "--body", opts.body,
+  ];
+  const result = gh(args);
+  if (!result.ok) {
+    throw new Error(`gh issue create failed: ${result.stderr}`);
+  }
+  const url = result.stdout.trim();
+  const issueNumberMatch = url.match(/\/issues\/(\d+)/);
+  const number = issueNumberMatch ? parseInt(issueNumberMatch[1], 10) : 0;
+  return { number, url };
+}
+
 export function ghIssueClose(repo: string, issueNumber: number): boolean {
   const result = gh(["issue", "close", String(issueNumber), "-R", repo]);
   return result.ok;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -46,11 +46,13 @@ export enum EventType {
   GatePassed = "gate_passed",
   GateFailed = "gate_failed",
 
-  // Merge
+  // Merge & Issues
   PrCreated = "pr_created",
   CiPassed = "ci_passed",
   CiFailed = "ci_failed",
   PrMerged = "pr_merged",
+  IssueCreated = "issue_created",
+  IssueCreateFailed = "issue_create_failed",
 
   // Cost
   BudgetWarning = "budget_warning",

--- a/tests/broker/github-sync.test.ts
+++ b/tests/broker/github-sync.test.ts
@@ -1,0 +1,161 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { createTestDb } from "../fixtures/helpers";
+import { createIssueForTask, formatIssueBody } from "../../src/broker/github-sync";
+import type { Database } from "../../src/broker/db";
+
+describe("formatIssueBody", () => {
+  test("includes description, task ID, and path", () => {
+    const body = formatIssueBody({
+      id: "W-042",
+      description: "Fix the login bug",
+      path_name: "development",
+    });
+    expect(body).toContain("Fix the login bug");
+    expect(body).toContain("**Task:** W-042");
+    expect(body).toContain("**Path:** development");
+    expect(body).toContain("Grove");
+  });
+
+  test("uses placeholder when description is null", () => {
+    const body = formatIssueBody({
+      id: "W-001",
+      description: null,
+      path_name: "research",
+    });
+    expect(body).toContain("No description provided.");
+    expect(body).toContain("**Task:** W-001");
+  });
+});
+
+describe("createIssueForTask", () => {
+  let db: Database;
+  let cleanup: () => void;
+  let mockGhIssueCreate: ReturnType<typeof createMockGhIssueCreate>;
+
+  function createMockGhIssueCreate(issueNumber: number = 99) {
+    const calls: Array<{ repo: string; opts: { title: string; body: string } }> = [];
+    const fn = (repo: string, opts: { title: string; body: string }) => {
+      calls.push({ repo, opts });
+      return { number: issueNumber, url: `https://github.com/${repo}/issues/${issueNumber}` };
+    };
+    return Object.assign(fn, { calls });
+  }
+
+  beforeEach(() => {
+    ({ db, cleanup } = createTestDb());
+    // Create a tree with github configured
+    db.treeUpsert({
+      id: "my-app",
+      name: "my-app",
+      path: "/tmp/my-app",
+      github: "owner/my-app",
+      branch_prefix: "grove/",
+    });
+    // Create a tree without github
+    db.treeUpsert({
+      id: "local-only",
+      name: "local-only",
+      path: "/tmp/local",
+    });
+    mockGhIssueCreate = createMockGhIssueCreate();
+  });
+
+  afterEach(() => cleanup());
+
+  test("creates issue and stores number for task with tree+github", () => {
+    const taskId = db.nextTaskId("W");
+    db.run(
+      "INSERT INTO tasks (id, tree_id, title, description, path_name, status) VALUES (?, ?, ?, ?, ?, 'draft')",
+      [taskId, "my-app", "Add dark mode", "Implement dark mode toggle", "development"],
+    );
+
+    const result = createIssueForTask(db, taskId, mockGhIssueCreate);
+
+    expect(result).toBe(99);
+    expect(mockGhIssueCreate.calls).toHaveLength(1);
+    expect(mockGhIssueCreate.calls[0].repo).toBe("owner/my-app");
+    expect(mockGhIssueCreate.calls[0].opts.title).toBe("Add dark mode");
+    expect(mockGhIssueCreate.calls[0].opts.body).toContain("Implement dark mode toggle");
+    expect(mockGhIssueCreate.calls[0].opts.body).toContain(taskId);
+
+    // Verify DB was updated
+    const task = db.taskGet(taskId);
+    expect(task!.github_issue).toBe(99);
+
+    // Verify event was logged
+    const events = db.eventsByTask(taskId);
+    const issueEvent = events.find(e => e.event_type === "issue_created");
+    expect(issueEvent).toBeDefined();
+    expect(issueEvent!.summary).toContain("#99");
+  });
+
+  test("skips task that already has a github_issue", () => {
+    const taskId = db.nextTaskId("W");
+    db.run(
+      "INSERT INTO tasks (id, tree_id, title, description, path_name, status, github_issue) VALUES (?, ?, ?, ?, ?, 'draft', ?)",
+      [taskId, "my-app", "Imported Issue", "From GitHub", "development", 42],
+    );
+
+    const result = createIssueForTask(db, taskId, mockGhIssueCreate);
+
+    expect(result).toBeNull();
+    expect(mockGhIssueCreate.calls).toHaveLength(0);
+  });
+
+  test("skips task with no tree_id", () => {
+    const taskId = db.nextTaskId("W");
+    db.run(
+      "INSERT INTO tasks (id, tree_id, title, description, path_name, status) VALUES (?, ?, ?, ?, ?, 'draft')",
+      [taskId, null, "Orphan task", null, "development"],
+    );
+
+    const result = createIssueForTask(db, taskId, mockGhIssueCreate);
+
+    expect(result).toBeNull();
+    expect(mockGhIssueCreate.calls).toHaveLength(0);
+  });
+
+  test("skips task whose tree has no github configured", () => {
+    const taskId = db.nextTaskId("W");
+    db.run(
+      "INSERT INTO tasks (id, tree_id, title, description, path_name, status) VALUES (?, ?, ?, ?, ?, 'draft')",
+      [taskId, "local-only", "Local task", null, "development"],
+    );
+
+    const result = createIssueForTask(db, taskId, mockGhIssueCreate);
+
+    expect(result).toBeNull();
+    expect(mockGhIssueCreate.calls).toHaveLength(0);
+  });
+
+  test("returns null for nonexistent task", () => {
+    const result = createIssueForTask(db, "W-999", mockGhIssueCreate);
+    expect(result).toBeNull();
+  });
+
+  test("handles gh CLI failure gracefully", () => {
+    const taskId = db.nextTaskId("W");
+    db.run(
+      "INSERT INTO tasks (id, tree_id, title, description, path_name, status) VALUES (?, ?, ?, ?, ?, 'draft')",
+      [taskId, "my-app", "Will fail", null, "development"],
+    );
+
+    const failingCreate = () => {
+      throw new Error("gh: authentication required");
+    };
+
+    const result = createIssueForTask(db, taskId, failingCreate);
+
+    expect(result).toBeNull();
+
+    // github_issue should remain null
+    const task = db.taskGet(taskId);
+    expect(task!.github_issue).toBeNull();
+
+    // Failure event should be logged
+    const events = db.eventsByTask(taskId);
+    const failEvent = events.find(e => e.event_type === "issue_create_failed");
+    expect(failEvent).toBeDefined();
+    expect(failEvent!.summary).toContain("authentication required");
+  });
+});


### PR DESCRIPTION
## Auto-create GitHub issues when tasks are created in Grove Issue #57

## Problem

Tasks created inside Grove (via the GUI or orchestrator) have no corresponding GitHub issue. This means:
- `github_issue` is NULL in the DB, so auto-close on merge doesn't fire
- Work done in Grove isn't visible in GitHub's issue tracker
- The only path that links issues is the reverse: importing GitHub issues into Grove

## Desired Behavior

When a task is created — regardless of source (GUI, orchestrator, or API) — Grove should:
1. Call `gh issue create` (or the GitHub API) on the task's tree repo
2. Store the issue number in `tasks.github_issue`
3. The existing merge manager logic (`ghIssueClose`) then auto-closes the issue on PR merge

### Considerations
- Should be gated on the tree having a `github` repo configured (skip silently if not)
- Issue body should include the task description and task ID for traceability
- The orchestrator creates tasks via `db.nextTaskId()` + INSERT — this path also needs the hook
- For tasks without a tree assignment yet, defer issue creation until tree is assigned

---
*Created by Grove dogfooding session*

**Task:** W-029
**Path:** development
**Cost:** $0.00
**Files changed:** 9

### Quality Gates
- commits: passed — 1 commit on branch
- tests: passed — No test command configured — skipped
- diff_size: passed — 338 lines changed

Closes #57

---
*Created by [Grove](https://grove.cloud)*