### PR TITLE
feat: (W-028) UX: Improve task status filter tabs Issue #58

### DIFF
--- a/web/src/components/TaskList.tsx
+++ b/web/src/components/TaskList.tsx
@@ -41,7 +41,7 @@ export default function TaskList({ tasks, trees, paths, getActivity, getActivity
   useEffect(() => {
     if (wsMessage) seedState.handleWsMessage(wsMessage);
   }, [wsMessage, seedState.handleWsMessage]);
-  const [filter, setFilter] = useState<"all" | "active" | "done">("active");
+  const [filter, setFilter] = useState<"all" | "active" | "failed" | "done">("active");
   const [showNewTask, setShowNewTask] = useState(false);
   const [newTitle, setNewTitle] = useState("");
   const [newDescription, setNewDescription] = useState("");
@@ -127,7 +127,8 @@ export default function TaskList({ tasks, trees, paths, getActivity, getActivity
 
   const filtered = tasks.filter((t) => {
     if (filter === "active") return ["draft", "queued", "active"].includes(t.status);
-    if (filter === "done") return ["completed"].includes(t.status);
+    if (filter === "failed") return t.status === "failed";
+    if (filter === "done") return t.status === "completed";
     return true;
   });
 
@@ -143,7 +144,7 @@ export default function TaskList({ tasks, trees, paths, getActivity, getActivity
           >
             + New
           </button>
-          {(["all", "active", "done"] as const).map((f) => (
+          {(["all", "active", "failed", "done"] as const).map((f) => (
             <button
               key={f}
               onClick={() => setFilter(f)}


### PR DESCRIPTION
## UX: Improve task status filter tabs Issue #58

## Problem

Current filter tabs are `All | Active | Done`:
- "Active" lumps together draft, queued, and actively-running tasks
- **Failed tasks are hidden** — no filter shows them, so they silently disappear
- No quick way to see just what's running vs what's waiting

## Proposal

Replace with: **All | Active | Failed | Done**

- **All**: every task
- **Active**: draft + queued + active (the full pipeline — tasks not yet completed or failed)
- **Failed**: failed tasks only — these need attention
- **Done**: completed tasks

### Open Question
- Should "Active" be split further (e.g., separate "Queued" and "Running")? Probably not — tasks move through queued quickly and the granularity adds clutter without much value. The pipeline indicator on each task card already shows the current step.

### Label alignment
Keep `draft` and `queued` as distinct backend statuses — they represent real state differences (not yet dispatched vs ready for dispatch). The filter just groups them under "Active" for the UI.

---
*Created by Grove dogfooding session*

**Task:** W-028
**Path:** development
**Cost:** $0.00
**Files changed:** 10

### Quality Gates
- commits: passed — 1 commit on branch
- tests: passed — No test command configured — skipped
- diff_size: passed — 7 lines changed

Closes #58

---
*Created by [Grove](https://grove.cloud)*