### PR TITLE
feat: (W-025) UX: Filter and tree selection should persist across state...

### DIFF
--- a/web/src/components/TaskList.tsx
+++ b/web/src/components/TaskList.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useLocalStorage } from "../hooks/useLocalStorage";
 import { api } from "../api/client";
 import type { Task, Tree } from "../hooks/useTasks";
 import TaskDetail from "./TaskDetail";
@@ -41,7 +42,7 @@ export default function TaskList({ tasks, trees, paths, getActivity, getActivity
   useEffect(() => {
     if (wsMessage) seedState.handleWsMessage(wsMessage);
   }, [wsMessage, seedState.handleWsMessage]);
-  const [filter, setFilter] = useState<"all" | "active" | "failed" | "done">("active");
+  const [filter, setFilter] = useLocalStorage<"all" | "active" | "failed" | "done">("grove-task-filter", "active");
   const [showNewTask, setShowNewTask] = useState(false);
   const [newTitle, setNewTitle] = useState("");
   const [newDescription, setNewDescription] = useState("");

--- a/web/src/hooks/useTasks.ts
+++ b/web/src/hooks/useTasks.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import type { WsMessage } from "./useWebSocket";
+import { useLocalStorage } from "./useLocalStorage";
 import { api } from "../api/client";
 
 export interface Task {
@@ -62,7 +63,7 @@ export function useTasks() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [trees, setTrees] = useState<Tree[]>([]);
   const [status, setStatus] = useState<Status | null>(null);
-  const [selectedTree, setSelectedTree] = useState<string | null>(null);
+  const [selectedTree, setSelectedTree] = useLocalStorage<string | null>("grove-selected-tree", null);
   const [paths, setPaths] = useState<Record<string, { description: string; steps: Array<{ id: string; type: string; label: string; on_success: string; on_failure: string }> }>>({});
 
   const refresh = useCallback(async () => {


### PR DESCRIPTION
## UX: Filter and tree selection should persist across state changes Issue #61

## Problem

When a task transitions pipeline states (e.g., plan → implement), the task list refreshes and resets to showing all tasks with the default filter. The user's sidebar tree selection and status filter are lost.

This is because:
- Filter state is `useState` in `TaskList` (resets on re-render)
- Tree selection is `useState` in `useTasks` hook (resets on refresh)
- Neither is persisted to localStorage or URL params

## Desired Behavior

1. **Tree selection** and **status filter** should persist:
   - Across task state transitions (pipeline step changes)
   - Across page reloads (browser refresh)
   - When Grove first opens (restore last selection)

2. **Implementation options** (in order of preference):
   - **localStorage**: simplest, matches how pane widths are already stored in `lib/pane-storage.ts`
   - **URL search params**: enables shareable deep links but adds complexity
   - localStorage is probably sufficient for now

3. The WebSocket `task:status` events that trigger re-fetches should preserve the current filter/tree state, not reset it.

---
*Created by Grove dogfooding session*

**Task:** W-025
**Path:** development
**Cost:** $0.00
**Files changed:** 11

### Quality Gates
- commits: passed — 1 commit on branch
- tests: passed — No test command configured — skipped
- diff_size: passed — 6 lines changed

Closes #61

---
*Created by [Grove](https://grove.cloud)*