### PR TITLE
feat: (W-027) UX: Sidebar — rename All Tasks, add task counts per tree...

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,13 +1,15 @@
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import { useWebSocket, type WsMessage } from "./hooks/useWebSocket";
 
-import { useTasks } from "./hooks/useTasks";
+import { useTasks, type Task } from "./hooks/useTasks";
 import { useChat } from "./hooks/useChat";
 import Sidebar from "./components/Sidebar";
 import TaskList from "./components/TaskList";
 import Chat from "./components/Chat";
 import Settings from "./components/Settings";
 import Dashboard from "./components/Dashboard";
+
+export type StatusFilter = "all" | "active" | "failed" | "done";
 
 type View = "tasks" | "settings" | "dashboard";
 type MobileTab = "trees" | "tasks" | "chat";
@@ -80,9 +82,32 @@ export default function App() {
   const sidebar = useDragResize(240, 160, 400, "left");
   const chat = useDragResize(320, 200, 600, "right");
 
-  const activeTaskCount = taskState.tasks.filter(t =>
-    ["draft", "queued", "active"].includes(t.status)
-  ).length || taskState.tasks.length;
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("active");
+
+  /** Apply status filter to a task list */
+  const applyStatusFilter = useCallback((tasks: Task[], filter: StatusFilter) => {
+    if (filter === "active") return tasks.filter(t => ["draft", "queued", "active"].includes(t.status));
+    if (filter === "failed") return tasks.filter(t => t.status === "failed");
+    if (filter === "done") return tasks.filter(t => t.status === "completed");
+    return tasks;
+  }, []);
+
+  /** Tasks filtered by status (for counts), then further by selected tree (for display) */
+  const statusFiltered = useMemo(() => applyStatusFilter(taskState.tasks, statusFilter), [taskState.tasks, statusFilter, applyStatusFilter]);
+  const displayedTasks = useMemo(() => {
+    if (!taskState.selectedTree) return statusFiltered;
+    return statusFiltered.filter(t => t.tree_id === taskState.selectedTree);
+  }, [statusFiltered, taskState.selectedTree]);
+
+  /** Per-tree task counts reflecting the active status filter */
+  const treeCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const t of statusFiltered) {
+      const key = t.tree_id ?? "__none__";
+      counts[key] = (counts[key] ?? 0) + 1;
+    }
+    return counts;
+  }, [statusFiltered]);
 
   if (isMobile) {
     return (
@@ -93,7 +118,8 @@ export default function App() {
             <Sidebar
               trees={taskState.trees}
               status={taskState.status}
-              taskCount={activeTaskCount}
+              taskCount={statusFiltered.length}
+              treeCounts={treeCounts}
               selectedTree={taskState.selectedTree}
               onSelectTree={(id) => {
                 taskState.setSelectedTree(id);
@@ -108,7 +134,7 @@ export default function App() {
           {mobileTab === "tasks" && (
             view === "tasks" ? (
               <TaskList
-                tasks={taskState.tasks}
+                tasks={displayedTasks}
                 trees={taskState.trees}
                 paths={taskState.paths}
                 getActivity={taskState.getActivity}
@@ -117,6 +143,8 @@ export default function App() {
                 onRefresh={taskState.refresh}
                 send={send}
                 wsMessage={lastWsMsg}
+                filter={statusFilter}
+                onFilterChange={setStatusFilter}
               />
             ) : view === "dashboard" ? (
               <Dashboard wsMessages={wsMessages} status={taskState.status} />
@@ -170,7 +198,8 @@ export default function App() {
         <Sidebar
           trees={taskState.trees}
           status={taskState.status}
-          taskCount={activeTaskCount}
+          taskCount={statusFiltered.length}
+          treeCounts={treeCounts}
           selectedTree={taskState.selectedTree}
           onSelectTree={(id) => {
             taskState.setSelectedTree(id);
@@ -192,7 +221,7 @@ export default function App() {
       <main className="flex-1 min-w-0 overflow-y-auto">
         {view === "tasks" ? (
           <TaskList
-            tasks={taskState.tasks}
+            tasks={displayedTasks}
             trees={taskState.trees}
             paths={taskState.paths}
             getActivity={taskState.getActivity}
@@ -201,6 +230,8 @@ export default function App() {
             onRefresh={taskState.refresh}
             send={send}
             wsMessage={lastWsMsg}
+            filter={statusFilter}
+            onFilterChange={setStatusFilter}
           />
         ) : view === "dashboard" ? (
           <Dashboard wsMessages={wsMessages} status={taskState.status} />

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -22,6 +22,7 @@ interface Props {
   trees: Tree[];
   status: Status | null;
   taskCount: number;
+  treeCounts: Record<string, number>;
   selectedTree: string | null;
   onSelectTree: (id: string | null) => void;
   connected: boolean;
@@ -29,7 +30,7 @@ interface Props {
   onDashboardClick: () => void;
 }
 
-export default function Sidebar({ trees, status, taskCount, selectedTree, onSelectTree, connected, onSettingsClick, onDashboardClick }: Props) {
+export default function Sidebar({ trees, status, taskCount, treeCounts, selectedTree, onSelectTree, connected, onSettingsClick, onDashboardClick }: Props) {
   return (
     <aside className="h-full flex flex-col bg-zinc-900/50 p-4 text-sm overflow-y-auto">
       {/* Header: Logo + Gear */}
@@ -38,15 +39,19 @@ export default function Sidebar({ trees, status, taskCount, selectedTree, onSele
         <button onClick={onSettingsClick} className="text-zinc-500 hover:text-zinc-300 text-lg" title="Settings">&#9881;</button>
       </div>
 
-      {/* All Tasks */}
+      {/* The Grove (all trees) */}
       <button
         onClick={() => onSelectTree(null)}
-        className={`w-full text-left px-2 py-1.5 rounded text-sm flex justify-between mb-4 ${
+        className={`w-full text-left px-2 py-1.5 rounded text-sm flex justify-between items-center mb-4 ${
           selectedTree === null ? "bg-emerald-400/10 text-emerald-400" : "text-zinc-400 hover:text-zinc-200"
         }`}
       >
-        <span>All Tasks</span>
-        <span className="text-[11px] opacity-70">{taskCount}</span>
+        <span>The Grove</span>
+        {taskCount > 0 && (
+          <span className="text-[10px] bg-emerald-400/15 text-emerald-400 px-1.5 py-0.5 rounded-full min-w-[20px] text-center">
+            {taskCount}
+          </span>
+        )}
       </button>
 
       <button
@@ -67,20 +72,33 @@ export default function Sidebar({ trees, status, taskCount, selectedTree, onSele
           <div key={org} className="mb-3">
             <div className="flex justify-between items-center px-2 py-0.5">
               <div className="text-zinc-600 text-[10px] uppercase tracking-wider">{org}</div>
-              <span className="text-zinc-600 text-[10px]">{orgTrees.length}</span>
+              {(() => {
+                const orgCount = orgTrees.reduce((sum, t) => sum + (treeCounts[t.id] ?? 0), 0);
+                return orgCount > 0
+                  ? <span className="text-zinc-500 text-[10px]">{orgCount}</span>
+                  : <span className="text-zinc-700 text-[10px]">{orgTrees.length} trees</span>;
+              })()}
             </div>
-            {orgTrees.map((tree) => (
-              <button
-                key={tree.id}
-                onClick={() => onSelectTree(tree.id)}
-                className={`w-full text-left px-2 py-1 rounded text-sm truncate ${
-                  selectedTree === tree.id ? "bg-emerald-400/10 text-emerald-400" : "text-zinc-400 hover:text-zinc-200"
-                }`}
-                title={tree.path}
-              >
-                {tree.name}
-              </button>
-            ))}
+            {orgTrees.map((tree) => {
+              const count = treeCounts[tree.id] ?? 0;
+              return (
+                <button
+                  key={tree.id}
+                  onClick={() => onSelectTree(tree.id)}
+                  className={`w-full text-left px-2 py-1 rounded text-sm flex justify-between items-center ${
+                    selectedTree === tree.id ? "bg-emerald-400/10 text-emerald-400" : "text-zinc-400 hover:text-zinc-200"
+                  }`}
+                  title={tree.path}
+                >
+                  <span className="truncate">{tree.name}</span>
+                  {count > 0 && (
+                    <span className="text-[10px] text-zinc-500 bg-zinc-800 px-1.5 py-0.5 rounded-full min-w-[20px] text-center flex-shrink-0 ml-1">
+                      {count}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
           </div>
         ))}
         {trees.length === 0 && (

--- a/web/src/components/TaskList.tsx
+++ b/web/src/components/TaskList.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
-import { useLocalStorage } from "../hooks/useLocalStorage";
 import { api } from "../api/client";
 import type { Task, Tree } from "../hooks/useTasks";
+import type { StatusFilter } from "../App";
 import TaskDetail from "./TaskDetail";
 import Pipeline from "./Pipeline";
 import SeedBadge from "./SeedBadge";
@@ -19,6 +19,8 @@ interface Props {
   onRefresh: () => void;
   send: (data: any) => void;
   wsMessage?: WsMessage | null;
+  filter: StatusFilter;
+  onFilterChange: (f: StatusFilter) => void;
 }
 
 const STATUS_COLORS: Record<string, string> = {
@@ -35,14 +37,13 @@ const STATUS_BORDER: Record<string, string> = {
   failed: "border-red-500/30",
 };
 
-export default function TaskList({ tasks, trees, paths, getActivity, getActivityLog, loadActivityLog, onRefresh, send, wsMessage }: Props) {
+export default function TaskList({ tasks, trees, paths, getActivity, getActivityLog, loadActivityLog, onRefresh, send, wsMessage, filter, onFilterChange }: Props) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const seedState = useSeed(expandedId, send);
 
   useEffect(() => {
     if (wsMessage) seedState.handleWsMessage(wsMessage);
   }, [wsMessage, seedState.handleWsMessage]);
-  const [filter, setFilter] = useLocalStorage<"all" | "active" | "failed" | "done">("grove-task-filter", "active");
   const [showNewTask, setShowNewTask] = useState(false);
   const [newTitle, setNewTitle] = useState("");
   const [newDescription, setNewDescription] = useState("");
@@ -126,12 +127,8 @@ export default function TaskList({ tasks, trees, paths, getActivity, getActivity
     }
   };
 
-  const filtered = tasks.filter((t) => {
-    if (filter === "active") return ["draft", "queued", "active"].includes(t.status);
-    if (filter === "failed") return t.status === "failed";
-    if (filter === "done") return t.status === "completed";
-    return true;
-  });
+  // Tasks are already filtered by status + tree in App.tsx
+  const filtered = tasks;
 
   return (
     <div className="p-5">
@@ -148,7 +145,7 @@ export default function TaskList({ tasks, trees, paths, getActivity, getActivity
           {(["all", "active", "failed", "done"] as const).map((f) => (
             <button
               key={f}
-              onClick={() => setFilter(f)}
+              onClick={() => onFilterChange(f)}
               className={`px-3 py-1 rounded-full capitalize ${
                 filter === f
                   ? "bg-emerald-400/15 text-emerald-400"

--- a/web/src/hooks/useTasks.ts
+++ b/web/src/hooks/useTasks.ts
@@ -69,7 +69,7 @@ export function useTasks() {
   const refresh = useCallback(async () => {
     try {
       const [tasksData, treesData, statusData, pathsData] = await Promise.all([
-        api<Task[]>(selectedTree ? `/api/tasks?tree=${selectedTree}` : "/api/tasks"),
+        api<Task[]>("/api/tasks"),
         api<Tree[]>("/api/trees"),
         api<Status>("/api/status"),
         api<Record<string, any>>("/api/paths"),
@@ -81,7 +81,7 @@ export function useTasks() {
     } catch {
       // API not available
     }
-  }, [selectedTree]);
+  }, []);
 
   useEffect(() => {
     refresh();


### PR DESCRIPTION
## UX: Sidebar — rename All Tasks, add task counts per tree Issue #59

## Problem

- The "All Tasks" link at the top of the sidebar doesn't describe what it does well — it's really a tree-level deselection (show tasks across all trees)
- Individual trees in the sidebar don't show how many tasks they have, making it hard to see where work is concentrated

## Proposal

1. **Rename "All Tasks"** to **"The Grove"** or **"All Trees"** with a badge showing total task count
2. **Add task count badges to each tree** in the sidebar (e.g., `wheels (3)` or a small pill/badge)

### Counts should reflect the active filter
- If the status filter is "Failed", the sidebar counts should show failed task counts per tree
- If "All", show total counts
- This ties into the additive filtering behavior (see related issue)

---
*Created by Grove dogfooding session*

**Task:** W-027
**Path:** development
**Cost:** $0.00
**Files changed:** 13

### Quality Gates
- commits: passed — 1 commit on branch
- tests: passed — No test command configured — skipped
- diff_size: passed — 124 lines changed

Closes #59

---
*Created by [Grove](https://grove.cloud)*