### PR TITLE
feat: (W-026) UX: Tree selection and status filter should be additive...

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import { useWebSocket, type WsMessage } from "./hooks/useWebSocket";
 
 import { useTasks, type Task } from "./hooks/useTasks";
+import { useLocalStorage } from "./hooks/useLocalStorage";
 import { useChat } from "./hooks/useChat";
 import Sidebar from "./components/Sidebar";
 import TaskList from "./components/TaskList";
@@ -82,7 +83,7 @@ export default function App() {
   const sidebar = useDragResize(240, 160, 400, "left");
   const chat = useDragResize(320, 200, 600, "right");
 
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>("active");
+  const [statusFilter, setStatusFilter] = useLocalStorage<StatusFilter>("grove-status-filter", "active");
 
   /** Apply status filter to a task list */
   const applyStatusFilter = useCallback((tasks: Task[], filter: StatusFilter) => {
@@ -98,6 +99,11 @@ export default function App() {
     if (!taskState.selectedTree) return statusFiltered;
     return statusFiltered.filter(t => t.tree_id === taskState.selectedTree);
   }, [statusFiltered, taskState.selectedTree]);
+
+  const selectedTreeName = useMemo(() => {
+    if (!taskState.selectedTree) return null;
+    return taskState.trees.find(t => t.id === taskState.selectedTree)?.name ?? null;
+  }, [taskState.selectedTree, taskState.trees]);
 
   /** Per-tree task counts reflecting the active status filter */
   const treeCounts = useMemo(() => {
@@ -145,6 +151,7 @@ export default function App() {
                 wsMessage={lastWsMsg}
                 filter={statusFilter}
                 onFilterChange={setStatusFilter}
+                selectedTreeName={selectedTreeName}
               />
             ) : view === "dashboard" ? (
               <Dashboard wsMessages={wsMessages} status={taskState.status} />
@@ -232,6 +239,7 @@ export default function App() {
             wsMessage={lastWsMsg}
             filter={statusFilter}
             onFilterChange={setStatusFilter}
+            selectedTreeName={selectedTreeName}
           />
         ) : view === "dashboard" ? (
           <Dashboard wsMessages={wsMessages} status={taskState.status} />

--- a/web/src/components/TaskList.tsx
+++ b/web/src/components/TaskList.tsx
@@ -21,6 +21,7 @@ interface Props {
   wsMessage?: WsMessage | null;
   filter: StatusFilter;
   onFilterChange: (f: StatusFilter) => void;
+  selectedTreeName?: string | null;
 }
 
 const STATUS_COLORS: Record<string, string> = {
@@ -37,7 +38,7 @@ const STATUS_BORDER: Record<string, string> = {
   failed: "border-red-500/30",
 };
 
-export default function TaskList({ tasks, trees, paths, getActivity, getActivityLog, loadActivityLog, onRefresh, send, wsMessage, filter, onFilterChange }: Props) {
+export default function TaskList({ tasks, trees, paths, getActivity, getActivityLog, loadActivityLog, onRefresh, send, wsMessage, filter, onFilterChange, selectedTreeName }: Props) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const seedState = useSeed(expandedId, send);
 
@@ -228,7 +229,7 @@ export default function TaskList({ tasks, trees, paths, getActivity, getActivity
       <div className="space-y-2">
         {filtered.length === 0 && (
           <div className="text-zinc-600 text-center py-12">
-            No tasks{filter !== "all" ? ` (${filter})` : ""}. Chat with the orchestrator to create one.
+            No {filter !== "all" ? `${filter} ` : ""}tasks{selectedTreeName ? ` in ${selectedTreeName}` : ""}.
           </div>
         )}
 


### PR DESCRIPTION
## UX: Tree selection and status filter should be additive (cross-filter) Issue #60

## Problem

Currently, tree selection (sidebar) and status filter (top bar) operate independently but the interaction isn't well-defined. Selecting a tree fetches only that tree's tasks via the API (`/api/tasks?tree=X`), then the status filter is applied client-side. This mostly works but the UX doesn't feel intentional.

## Desired Behavior

Tree selection and status filter should compose naturally:

| Sidebar | Top filter | Result |
|---------|-----------|--------|
| All Trees | All | Every task across all trees |
| All Trees | Active | All active tasks across all trees |
| All Trees | Failed | All failed tasks across all trees |
| wheels | All | All tasks for wheels |
| wheels | Failed | Only failed tasks for wheels |

This is mostly how it works today, but:
- Sidebar counts should reflect the active status filter (see sidebar issue)
- Filter state should be independent of tree selection (changing tree shouldn't reset filter)
- Both dimensions should persist (see persistence issue)

---
*Created by Grove dogfooding session*

**Task:** W-026
**Path:** development
**Cost:** $0.00
**Files changed:** 13

### Quality Gates
- commits: passed — 1 commit on branch
- tests: passed — No test command configured — skipped
- diff_size: passed — 15 lines changed

Closes #60

---
*Created by [Grove](https://grove.cloud)*