### PR TITLE
feat: (W-030) Bug: evaluator rebase-conflict loop causes infinite...

### DIFF
--- a/src/agents/evaluator.ts
+++ b/src/agents/evaluator.ts
@@ -10,10 +10,14 @@ import type { Task, Tree } from "../shared/types";
 
 export interface EvalResult {
   passed: boolean;
+  fatal?: boolean;
   gateResults: GateResult[];
   feedback: string;
   costUsd: number;
 }
+
+/** After this many consecutive rebase failures, mark the task as fatally failed. */
+export const MAX_REBASE_FAILURES = 3;
 
 export interface GateResult {
   gate: string;
@@ -280,10 +284,20 @@ export function evaluate(task: Task, tree: Tree, db: Database): EvalResult {
   // Rebase onto latest main before running gates — prevents stale-worktree bloat
   const rebaseResult = rebaseOntoMain(worktreePath, tree.config);
   if (!rebaseResult.ok) {
+    // Count previous consecutive rebase failures to detect infinite loops (W-030)
+    const prevRebaseFailures = db.scalar<number>(
+      "SELECT COUNT(*) FROM events WHERE task_id = ? AND event_type = 'eval_failed' AND summary LIKE 'Rebase failed%'",
+      [task.id],
+    ) ?? 0;
+    const fatal = prevRebaseFailures >= MAX_REBASE_FAILURES - 1;
+
     const result: EvalResult = {
       passed: false,
+      fatal,
       gateResults: [{ gate: "rebase", passed: false, tier: "hard", message: rebaseResult.message, output: rebaseResult.output }],
-      feedback: `Rebase failed: ${rebaseResult.message}`,
+      feedback: fatal
+        ? `Rebase conflict loop detected (${prevRebaseFailures + 1} consecutive failures) — needs manual resolution`
+        : `Rebase failed: ${rebaseResult.message}`,
       costUsd: 0,
     };
     db.run("UPDATE tasks SET gate_results = ? WHERE id = ?", [JSON.stringify(result.gateResults), task.id]);

--- a/src/engine/step-engine.ts
+++ b/src/engine/step-engine.ts
@@ -60,7 +60,7 @@ export function startPipeline(task: Task, tree: Tree, db: Database): void {
  */
 export function onStepComplete(
   taskId: string,
-  outcome: "success" | "failure",
+  outcome: "success" | "failure" | "fatal",
   context?: string,
 ): void {
   const db = _db;
@@ -68,6 +68,12 @@ export function onStepComplete(
 
   const task = db.taskGet(taskId);
   if (!task) return;
+
+  // Fatal failure — immediate task failure, no retry or transition (W-030)
+  if (outcome === "fatal") {
+    failTask(db, taskId, context ?? "Fatal failure — manual intervention required");
+    return;
+  }
 
   const paths = configNormalizedPaths();
   const pathConfig = paths[task.path_name];
@@ -200,7 +206,8 @@ async function executeStep(
     case "gate": {
       const { evaluate } = await import("../agents/evaluator");
       const result = evaluate(task, tree, db);
-      onStepComplete(task.id, result.passed ? "success" : "failure", result.feedback);
+      const gateOutcome = result.passed ? "success" : (result.fatal ? "fatal" : "failure");
+      onStepComplete(task.id, gateOutcome, result.feedback);
       break;
     }
 

--- a/tests/agents/evaluator-gates.test.ts
+++ b/tests/agents/evaluator-gates.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
-import { writeFileSync } from "node:fs";
+import { writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { createTestDb, createFixtureRepo } from "../fixtures/helpers";
 import {
   capOutput,
@@ -14,6 +15,7 @@ import {
   runGates,
   evaluate,
   buildRetryPrompt,
+  MAX_REBASE_FAILURES,
 } from "../../src/agents/evaluator";
 import { bus } from "../../src/broker/event-bus";
 import type { Database } from "../../src/broker/db";
@@ -499,5 +501,133 @@ describe("buildRetryPrompt", () => {
     );
     expect(prompt).toContain("Seed (Design Spec)");
     expect(prompt).toContain("Build a REST API with CRUD endpoints");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rebase conflict loop detection (W-030)
+// ---------------------------------------------------------------------------
+
+/**
+ * Create two repos that will produce a rebase conflict:
+ * - An "origin" repo with a commit on main that conflicts
+ * - A "worktree" clone on a feature branch with conflicting changes
+ */
+function createConflictingRepos(): { worktreePath: string; cleanup: () => void } {
+  // Create "origin" repo
+  const origin = createFixtureRepo();
+
+  // Clone it to create the "worktree" with a real remote
+  const worktreePath = join(tmpdir(), `grove-conflict-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  Bun.spawnSync(["git", "clone", origin.repoPath, worktreePath], { stdin: "ignore" });
+  Bun.spawnSync(["git", "config", "user.email", "test@grove.dev"], { cwd: worktreePath, stdin: "ignore" });
+  Bun.spawnSync(["git", "config", "user.name", "Grove Test"], { cwd: worktreePath, stdin: "ignore" });
+
+  // Create feature branch in worktree with conflicting change
+  Bun.spawnSync(["git", "checkout", "-b", "feature/conflict-test"], { cwd: worktreePath, stdin: "ignore" });
+  writeFileSync(join(worktreePath, "README.md"), "# Feature\nConflicting line from feature branch\n");
+  Bun.spawnSync(["git", "add", "."], { cwd: worktreePath, stdin: "ignore" });
+  Bun.spawnSync(["git", "commit", "-m", "feat: conflicting change"], { cwd: worktreePath, stdin: "ignore" });
+
+  // Push a conflicting change to origin's main
+  writeFileSync(join(origin.repoPath, "README.md"), "# Main\nConflicting line from main branch\n");
+  Bun.spawnSync(["git", "add", "."], { cwd: origin.repoPath, stdin: "ignore" });
+  Bun.spawnSync(["git", "commit", "-m", "chore: main diverges"], { cwd: origin.repoPath, stdin: "ignore" });
+
+  return {
+    worktreePath,
+    cleanup: () => {
+      origin.cleanup();
+      rmSync(worktreePath, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("rebase conflict loop detection", () => {
+  let db: Database;
+  let dbCleanup: () => void;
+
+  beforeEach(() => {
+    const result = createTestDb();
+    db = result.db;
+    dbCleanup = result.cleanup;
+    db.treeUpsert({ id: "t1", name: "Test", path: "/tmp/test" });
+  });
+
+  afterEach(() => {
+    bus.removeAll("eval:started");
+    bus.removeAll("eval:passed");
+    bus.removeAll("eval:failed");
+    bus.removeAll("gate:result");
+    dbCleanup();
+  });
+
+  test("exports MAX_REBASE_FAILURES constant", () => {
+    expect(MAX_REBASE_FAILURES).toBe(3);
+  });
+
+  test("first rebase failure is not fatal", () => {
+    const repos = createConflictingRepos();
+
+    db.run(
+      "INSERT INTO tasks (id, title, tree_id, status, worktree_path) VALUES (?, ?, ?, ?, ?)",
+      ["W-001", "Test", "t1", "active", repos.worktreePath],
+    );
+    const task = db.taskGet("W-001")!;
+    db.treeUpsert({ id: "t1", name: "Test", path: repos.worktreePath, config: "{}" });
+    const tree = db.treeGet("t1")!;
+
+    const result = evaluate(task, tree, db);
+    expect(result.passed).toBe(false);
+    expect(result.fatal).not.toBe(true);
+    expect(result.gateResults[0].gate).toBe("rebase");
+    repos.cleanup();
+  });
+
+  test("rebase failure becomes fatal after MAX_REBASE_FAILURES consecutive failures", () => {
+    const repos = createConflictingRepos();
+
+    db.run(
+      "INSERT INTO tasks (id, title, tree_id, status, worktree_path) VALUES (?, ?, ?, ?, ?)",
+      ["W-001", "Test", "t1", "active", repos.worktreePath],
+    );
+    db.treeUpsert({ id: "t1", name: "Test", path: repos.worktreePath, config: "{}" });
+
+    // Simulate MAX_REBASE_FAILURES - 1 previous rebase failures in event history
+    for (let i = 0; i < MAX_REBASE_FAILURES - 1; i++) {
+      db.addEvent("W-001", null, "eval_failed", "Rebase failed: Merge conflicts with origin/main — rebase aborted");
+    }
+
+    const task = db.taskGet("W-001")!;
+    const tree = db.treeGet("t1")!;
+
+    const result = evaluate(task, tree, db);
+    expect(result.passed).toBe(false);
+    expect(result.fatal).toBe(true);
+    expect(result.feedback).toContain("manual resolution");
+    repos.cleanup();
+  });
+
+  test("non-rebase eval failures do not count toward rebase failure limit", () => {
+    const repos = createConflictingRepos();
+
+    db.run(
+      "INSERT INTO tasks (id, title, tree_id, status, worktree_path) VALUES (?, ?, ?, ?, ?)",
+      ["W-001", "Test", "t1", "active", repos.worktreePath],
+    );
+    db.treeUpsert({ id: "t1", name: "Test", path: repos.worktreePath, config: "{}" });
+
+    // Add non-rebase eval failures — these should NOT count
+    for (let i = 0; i < 5; i++) {
+      db.addEvent("W-001", null, "eval_failed", "Evaluation failed: 1 hard failures");
+    }
+
+    const task = db.taskGet("W-001")!;
+    const tree = db.treeGet("t1")!;
+
+    const result = evaluate(task, tree, db);
+    expect(result.passed).toBe(false);
+    expect(result.fatal).not.toBe(true); // only 1st rebase failure, non-rebase failures ignored
+    repos.cleanup();
   });
 });

--- a/tests/engine/step-engine.test.ts
+++ b/tests/engine/step-engine.test.ts
@@ -392,4 +392,32 @@ describe("onStepComplete", () => {
     const updated = db.taskGet("T-106")!;
     expect(updated.status).toBe("failed");
   });
+
+  test("fatal outcome fails the task immediately, bypassing on_failure routing", () => {
+    createTaskAt("T-107", "evaluate", 2);
+
+    onStepComplete("T-107", "fatal", "Rebase conflict loop — needs manual resolution");
+
+    const updated = db.taskGet("T-107")!;
+    expect(updated.status).toBe("failed");
+    expect(updated.current_step).toBe("$fail");
+
+    // Verify event was logged with the context
+    const events = db.eventsByTask("T-107");
+    const failEvent = events.find(e => e.event_type === "task_failed");
+    expect(failEvent).toBeDefined();
+    expect(failEvent!.summary).toContain("Rebase conflict loop");
+  });
+
+  test("fatal outcome does not retry even when retries are available", () => {
+    createTaskAt("T-108", "evaluate", 2, { retry_count: 0, max_retries: 5 });
+
+    onStepComplete("T-108", "fatal", "Unrecoverable failure");
+
+    const updated = db.taskGet("T-108")!;
+    expect(updated.status).toBe("failed");
+    expect(updated.current_step).toBe("$fail");
+    // retry_count should NOT be incremented
+    expect(updated.retry_count).toBe(0);
+  });
 });


### PR DESCRIPTION
## Bug: evaluator rebase-conflict loop causes infinite implement→evaluate cycle Issue #67

When the evaluator rebase step fails due to merge conflicts with origin/main, it sends the task back to implement. The worker re-implements, returns to evaluate, rebase fails again — infinite loop. After N consecutive rebase failures (2-3), the task should be marked failed with a clear message indicating a rebase conflict needing manual resolution.

**Task:** W-030
**Path:** development
**Cost:** $0.00
**Files changed:** 17

### Quality Gates
- commits: passed — 1 commit on branch
- tests: passed — No test command configured — skipped
- diff_size: passed — 187 lines changed

Closes #71

---
*Created by [Grove](https://grove.cloud)*