### PR TITLE
feat: (W-038) Feature: adversarial review step type for plan-review loops...

### DIFF
--- a/docs/superpowers/specs/2026-03-30-adversarial-review-step-design.md
+++ b/docs/superpowers/specs/2026-03-30-adversarial-review-step-design.md
@@ -1,0 +1,129 @@
+# Adversarial Review Step Type — Design Spec
+
+**Issue**: #78
+**Task**: W-038
+**Date**: 2026-03-30
+
+## Problem
+
+The step engine supports `worker`, `gate`, and `merge` step types. There's no way to have two agents debate a plan before implementation — the planner and reviewer must be separate Claude sessions because models are poor self-critics.
+
+## Solution: `review` Step Type
+
+A new step type that spawns a read-only Claude CLI session to adversarially critique the output of a preceding worker step. On rejection, feedback is threaded back to the worker for revision, creating a plan-review loop.
+
+## Path Config
+
+```yaml
+paths:
+  adversarial:
+    description: Adversarial planning with review loop
+    steps:
+      - plan:
+          prompt: "Create a detailed implementation plan..."
+      - review:
+          type: review
+          prompt: "Critique this plan for correctness, backwards compatibility..."
+          on_failure: plan
+          max_retries: 3
+      - implement
+      - evaluate
+      - merge
+```
+
+## Architecture
+
+### Reviewer Agent (`src/agents/reviewer.ts`)
+
+Spawns a Claude CLI subprocess in the task's worktree:
+- **Read-only sandbox**: Write/Edit hooks block everything except `.grove/review-result.json`
+- **Prompt includes**: plan content (from `.grove/plan.md` or session summary), review criteria (from step prompt), prior review history
+- **Output**: Claude writes `.grove/review-result.json` → `{ "approved": boolean, "feedback": "..." }`
+- **On exit**: agent reads result file, maps to `onStepComplete` outcome
+
+### Feedback Threading
+
+When a review rejects the plan:
+1. Reviewer writes feedback to `.grove/review-feedback.md` in worktree
+2. `onStepComplete(taskId, "failure")` transitions to `on_failure` step (e.g., "plan")
+3. When the plan worker re-spawns, `deploySandbox` detects `.grove/review-feedback.md` and includes it in the CLAUDE.md overlay
+4. Planner sees: "The reviewer rejected your plan: [feedback]. Revise."
+
+### Loop Termination
+
+Follows the evaluator's rebase-failure-detection pattern:
+- Each review rejection logs a `review_rejected` event
+- Before each review, count prior `review_rejected` events for this task
+- If count >= `step.max_retries` (default 3), return `fatal: true`
+- Fatal outcome bypasses all retry/transition logic → task fails immediately
+
+### Sandbox Differences from Worker
+
+| Aspect | Worker | Reviewer |
+|--------|--------|----------|
+| Write/Edit | Allowed within worktree | Only `.grove/review-result.json` |
+| Session summary | Required | Not written |
+| Git commits | Expected | Blocked (no git add/commit) |
+| Strategy text | "Complete end-to-end" | "You are an adversarial reviewer" |
+| Overlay | Full task context | Plan content + review criteria |
+
+## Type Changes
+
+```typescript
+// PipelineStep.type
+type: "worker" | "gate" | "merge" | "review"
+
+// AgentRole enum
+Reviewer = "reviewer"
+
+// EventType additions
+ReviewStarted = "review_started"
+ReviewApproved = "review_approved"
+ReviewRejected = "review_rejected"
+
+// EventBusMap additions
+"review:started": { taskId: string; sessionId: string }
+"review:approved": { taskId: string; feedback?: string }
+"review:rejected": { taskId: string; feedback: string }
+```
+
+## Normalize Rules
+
+- String shorthand `"review"` infers `type: "review"`
+- Review steps auto-wire `on_failure` to nearest preceding worker (same as gates)
+
+## DEFAULT_PATHS Addition
+
+```typescript
+adversarial: {
+  description: "Adversarial planning with review loop",
+  steps: [
+    { id: "plan", type: "worker", prompt: "Create a detailed implementation plan..." },
+    { id: "review", type: "review", prompt: "Critique this plan...", on_failure: "plan", max_retries: 3 },
+    { id: "implement", type: "worker", prompt: "Implement the approved plan..." },
+    { id: "evaluate", type: "gate", on_failure: "implement" },
+    { id: "merge", type: "merge" },
+  ],
+}
+```
+
+## Files to Create
+
+- `src/agents/reviewer.ts` — Reviewer agent
+
+## Files to Modify
+
+- `src/shared/types.ts` — Type additions
+- `src/engine/normalize.ts` — `review` in TYPE_INFERENCE + auto-wire
+- `src/engine/step-engine.ts` — `review` case in executeStep
+- `src/shared/sandbox.ts` — Review overlay + review feedback inclusion
+- `src/agents/worker.ts` — Read review feedback into overlay context
+- `tests/engine/step-engine.test.ts` — Review step transition tests
+- `tests/agents/reviewer.test.ts` — New test file
+
+## Open Questions (Resolved)
+
+- **Reviewer codebase access**: Yes, reviewer has full read access to the worktree (not just the plan file). This lets it verify references, check existing APIs, etc.
+- **Structured plan format**: Freeform markdown (`.grove/plan.md`). Structure is enforced by the step prompt, not the framework.
+- **Reuse evaluator infrastructure**: No. Reviewer is a subprocess (separate Claude session); evaluator runs in-process (no Claude). Different enough to warrant its own module.
+- **Conversation history in UI**: Review feedback persists as events in the events table, visible in the task timeline.

--- a/src/agents/reviewer.ts
+++ b/src/agents/reviewer.ts
@@ -1,0 +1,279 @@
+// Grove v3 — Reviewer agent: adversarial plan review via Claude Code sessions
+// Spawns a read-only Claude session that critiques worker output (plans).
+// Returns structured pass/fail with feedback for the plan-review loop.
+import { join } from "node:path";
+import { mkdirSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { bus } from "../broker/event-bus";
+import { parseCost } from "./stream-parser";
+import { deployReviewSandbox, reviewTriggerPrompt } from "../shared/sandbox";
+import type { ReviewOverlayContext } from "../shared/sandbox";
+import type { Database } from "../broker/db";
+import type { Task, Tree } from "../shared/types";
+
+export interface ReviewResult {
+  approved: boolean;
+  feedback: string;
+  fatal?: boolean;
+  costUsd: number;
+}
+
+/** Default max review iterations before marking the task as fatally failed */
+export const DEFAULT_MAX_REVIEW_RETRIES = 3;
+
+/**
+ * Spawn a reviewer agent for a task. Reads the plan from the worktree,
+ * spawns a read-only Claude session to critique it, and reports the result.
+ */
+export function spawnReviewer(
+  task: Task,
+  tree: Tree,
+  db: Database,
+  logDir: string,
+  stepPrompt?: string,
+  maxRetries?: number,
+): void {
+  mkdirSync(logDir, { recursive: true });
+
+  const sessionId = `reviewer-${task.id}-${Date.now()}`;
+  const logPath = join(logDir, `${sessionId}.jsonl`);
+
+  const worktreePath = task.worktree_path;
+  if (!worktreePath || !existsSync(worktreePath)) {
+    db.addEvent(task.id, null, "review_rejected", "Worktree not found — cannot review");
+    bus.emit("review:rejected", { taskId: task.id, feedback: "Worktree not found" });
+    // Defer onStepComplete to avoid synchronous re-entry
+    setTimeout(async () => {
+      const { onStepComplete } = await import("../engine/step-engine");
+      onStepComplete(task.id, "failure", "Worktree not found — cannot review");
+    }, 0);
+    return;
+  }
+
+  // Check if we've exceeded max review iterations
+  const maxIter = maxRetries ?? DEFAULT_MAX_REVIEW_RETRIES;
+  const prevRejections = db.scalar<number>(
+    "SELECT COUNT(*) FROM events WHERE task_id = ? AND event_type = 'review_rejected'",
+    [task.id],
+  ) ?? 0;
+
+  if (prevRejections >= maxIter) {
+    db.addEvent(task.id, null, "review_rejected",
+      `Review loop exhausted (${prevRejections}/${maxIter} rejections) — plan not approved`);
+    bus.emit("review:rejected", { taskId: task.id, feedback: "Review loop exhausted" });
+    setTimeout(async () => {
+      const { onStepComplete } = await import("../engine/step-engine");
+      onStepComplete(task.id, "fatal", `Plan not approved after ${prevRejections} review cycles — manual intervention required`);
+    }, 0);
+    return;
+  }
+
+  // Read the plan from the worktree
+  const planContent = readPlanContent(worktreePath, task.session_summary);
+  if (!planContent) {
+    db.addEvent(task.id, null, "review_rejected", "No plan found in worktree");
+    bus.emit("review:rejected", { taskId: task.id, feedback: "No plan found" });
+    setTimeout(async () => {
+      const { onStepComplete } = await import("../engine/step-engine");
+      onStepComplete(task.id, "failure", "No plan found in worktree — nothing to review");
+    }, 0);
+    return;
+  }
+
+  // Gather prior review feedback for context threading
+  const priorFeedback = getPriorReviewFeedback(db, task.id);
+
+  // Deploy review sandbox (read-only guard hooks + review CLAUDE.md overlay)
+  const reviewCtx: ReviewOverlayContext = {
+    taskId: task.id,
+    title: task.title,
+    description: task.description,
+    treePath: tree.path,
+    stepPrompt,
+    planContent,
+    priorFeedback,
+  };
+  deployReviewSandbox(worktreePath, reviewCtx);
+
+  // Register session
+  db.sessionCreate(sessionId, task.id, "reviewer", undefined, undefined, logPath);
+  db.addEvent(task.id, sessionId, "review_started", `Review started (iteration ${prevRejections + 1}/${maxIter})`);
+  bus.emit("review:started", { taskId: task.id, sessionId });
+
+  const prompt = reviewTriggerPrompt(task.id);
+
+  // Spawn Claude CLI in the worktree (read-only via guard hooks)
+  const proc = Bun.spawn(
+    ["claude", "-p", prompt, "--verbose", "--output-format", "stream-json", "--dangerously-skip-permissions"],
+    {
+      cwd: worktreePath,
+      env: {
+        ...process.env,
+        GROVE_TASK_ID: task.id,
+        GROVE_WORKTREE_PATH: worktreePath,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+
+  db.addEvent(task.id, sessionId, "worker_spawned", `Reviewer spawned (PID: ${proc.pid})`);
+
+  // Monitor asynchronously
+  monitorReviewer(task.id, sessionId, logPath, worktreePath, proc, db);
+}
+
+// ---------------------------------------------------------------------------
+// Internal
+// ---------------------------------------------------------------------------
+
+/** Read plan content from worktree — tries .grove/plan.md then session summary */
+export function readPlanContent(worktreePath: string, sessionSummary?: string | null): string | null {
+  const planPath = join(worktreePath, ".grove", "plan.md");
+  if (existsSync(planPath)) {
+    try {
+      const content = readFileSync(planPath, "utf-8").trim();
+      if (content) return content;
+    } catch {}
+  }
+
+  // Fall back to session summary (planner may have written plan context there)
+  if (sessionSummary?.trim()) return sessionSummary;
+
+  return null;
+}
+
+/** Parse the review result from .grove/review-result.json */
+export function parseReviewResult(worktreePath: string): ReviewResult | null {
+  const resultPath = join(worktreePath, ".grove", "review-result.json");
+  if (!existsSync(resultPath)) return null;
+
+  try {
+    const raw = readFileSync(resultPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    return {
+      approved: Boolean(parsed.approved),
+      feedback: typeof parsed.feedback === "string" ? parsed.feedback : "No feedback provided",
+      costUsd: 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Get prior review feedback from event history */
+export function getPriorReviewFeedback(db: Database, taskId: string): string[] {
+  const events = db.all<{ summary: string }>(
+    "SELECT summary FROM events WHERE task_id = ? AND event_type = 'review_rejected' ORDER BY created_at ASC",
+    [taskId],
+  );
+  return events.map((e) => e.summary).filter(Boolean);
+}
+
+/** Write review feedback to worktree for the next planner iteration */
+function writeReviewFeedback(worktreePath: string, feedback: string): void {
+  const feedbackPath = join(worktreePath, ".grove", "review-feedback.md");
+  writeFileSync(feedbackPath, feedback);
+}
+
+/** Remove the review result file so it doesn't persist across iterations */
+function cleanupReviewResult(worktreePath: string): void {
+  const resultPath = join(worktreePath, ".grove", "review-result.json");
+  try { if (existsSync(resultPath)) Bun.spawnSync(["rm", resultPath]); } catch {}
+}
+
+/** Monitor a reviewer's stdout and handle completion */
+async function monitorReviewer(
+  taskId: string,
+  sessionId: string,
+  logPath: string,
+  worktreePath: string,
+  proc: ReturnType<typeof Bun.spawn>,
+  db: Database,
+): Promise<void> {
+  try {
+    // Read stdout and write to log
+    const stdout = proc.stdout;
+    if (!stdout || typeof stdout === "number") {
+      throw new Error("Reviewer stdout not available");
+    }
+    const reader = (stdout as ReadableStream<Uint8Array>).getReader();
+    const logFile = Bun.file(logPath);
+    const writer = logFile.writer();
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      const text = new TextDecoder().decode(value);
+      writer.write(text);
+      writer.flush();
+
+      // Parse activity events for UI
+      for (const line of text.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const obj = JSON.parse(trimmed);
+          if (obj.type === "assistant") {
+            for (const block of obj.message?.content ?? []) {
+              if (block.type === "tool_use") {
+                const tool = block.name ?? "tool";
+                const input = block.input ?? {};
+                const file = input.file_path ?? input.command ?? input.pattern ?? "";
+                bus.emit("worker:activity", { taskId, msg: `[reviewer] ${tool}: ${String(file).slice(0, 200)}` });
+              }
+            }
+          }
+          if (obj.type === "result" && obj.cost_usd != null) {
+            db.sessionUpdateCost(sessionId, Number(obj.cost_usd), Number(obj.usage?.input_tokens ?? 0) + Number(obj.usage?.output_tokens ?? 0));
+          }
+        } catch {}
+      }
+    }
+
+    writer.end();
+
+    // Wait for exit
+    const exitCode = await proc.exited;
+
+    // Parse cost
+    const cost = parseCost(logPath);
+    db.sessionUpdateCost(sessionId, cost.costUsd, cost.inputTokens + cost.outputTokens);
+    db.run("UPDATE tasks SET cost_usd = cost_usd + ?, tokens_used = tokens_used + ? WHERE id = ?",
+      [cost.costUsd, cost.inputTokens + cost.outputTokens, taskId]);
+
+    // Read structured result
+    const result = parseReviewResult(worktreePath);
+
+    if (!result || !result.approved) {
+      const feedback = result?.feedback ?? `Reviewer exited with code ${exitCode} without writing a verdict`;
+
+      // Persist feedback for the planner's next iteration
+      writeReviewFeedback(worktreePath, feedback);
+      cleanupReviewResult(worktreePath);
+
+      db.sessionEnd(sessionId, "failed");
+      db.addEvent(taskId, sessionId, "review_rejected", feedback);
+      bus.emit("review:rejected", { taskId, feedback });
+
+      const { onStepComplete } = await import("../engine/step-engine");
+      onStepComplete(taskId, "failure", feedback);
+    } else {
+      cleanupReviewResult(worktreePath);
+
+      db.sessionEnd(sessionId, "completed");
+      db.addEvent(taskId, sessionId, "review_approved", result.feedback || "Plan approved");
+      bus.emit("review:approved", { taskId, feedback: result.feedback });
+
+      const { onStepComplete } = await import("../engine/step-engine");
+      onStepComplete(taskId, "success");
+    }
+  } catch (err) {
+    db.sessionEnd(sessionId, "crashed");
+    db.addEvent(taskId, sessionId, "review_rejected", `Reviewer crashed: ${err}`);
+    bus.emit("review:rejected", { taskId, feedback: `Reviewer crashed: ${err}` });
+
+    const { onStepComplete } = await import("../engine/step-engine");
+    onStepComplete(taskId, "failure", `Reviewer crashed: ${err}`);
+  }
+}

--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -4,7 +4,7 @@ import { mkdirSync, existsSync, readFileSync } from "node:fs";
 import { bus } from "../broker/event-bus";
 import { parseCost, isAlive } from "./stream-parser";
 import { createWorktree, branchName } from "../shared/worktree";
-import { deploySandbox, triggerPrompt, resumeTriggerPrompt } from "../shared/sandbox";
+import { deploySandbox, triggerPrompt, resumeTriggerPrompt, readReviewFeedback } from "../shared/sandbox";
 import type { Database } from "../broker/db";
 import type { Task, Tree } from "../shared/types";
 
@@ -53,6 +53,9 @@ export function spawnWorker(task: Task, tree: Tree, db: Database, logDir: string
   const seed = db.seedGet(task.id);
   const seedSpec = seed?.spec ?? null;
 
+  // Check for review feedback from adversarial review loop
+  const reviewFeedback = readReviewFeedback(worktreePath);
+
   // Deploy sandbox (guard hooks + CLAUDE.md overlay with prior context)
   deploySandbox(worktreePath, {
     taskId: task.id,
@@ -65,6 +68,7 @@ export function spawnWorker(task: Task, tree: Tree, db: Database, logDir: string
     filesModified: task.files_modified,
     stepPrompt,
     seedSpec,
+    reviewFeedback,
   });
 
   // Update task in DB

--- a/src/engine/normalize.ts
+++ b/src/engine/normalize.ts
@@ -3,6 +3,7 @@ import type { PathConfig, PipelineStep, NormalizedPathConfig } from "../shared/t
 const TYPE_INFERENCE: Record<string, PipelineStep["type"]> = {
   merge: "merge",
   evaluate: "gate",
+  review: "review",
 };
 
 export function normalizePath(config: PathConfig): NormalizedPathConfig {
@@ -64,11 +65,11 @@ export function normalizePath(config: PathConfig): NormalizedPathConfig {
     }
   }
 
-  // Gate steps without explicit on_failure loop back to the nearest preceding worker.
+  // Gate and review steps without explicit on_failure loop back to the nearest preceding worker.
   // All other steps default to $fail.
   for (let i = 0; i < steps.length; i++) {
     if (steps[i].on_failure === "") {
-      if (steps[i].type === "gate") {
+      if (steps[i].type === "gate" || steps[i].type === "review") {
         for (let j = i - 1; j >= 0; j--) {
           if (steps[j].type === "worker") {
             steps[i].on_failure = steps[j].id;

--- a/src/engine/step-engine.ts
+++ b/src/engine/step-engine.ts
@@ -264,6 +264,14 @@ async function executeStep(
       break;
     }
 
+    case "review": {
+      const { spawnReviewer } = await import("../agents/reviewer");
+      const { getEnv } = await import("../broker/db");
+      const logDir = getEnv().GROVE_LOG_DIR;
+      spawnReviewer(task, tree, db, logDir, step.prompt, step.max_retries);
+      break;
+    }
+
     case "merge": {
       const { queueMerge } = await import("../merge/manager");
       queueMerge(task, tree, db);

--- a/src/shared/sandbox.ts
+++ b/src/shared/sandbox.ts
@@ -77,6 +77,17 @@ export interface OverlayContext {
   filesModified?: string | null;
   stepPrompt?: string;
   seedSpec?: string | null;
+  reviewFeedback?: string | null;
+}
+
+export interface ReviewOverlayContext {
+  taskId: string;
+  title: string;
+  description?: string | null;
+  treePath: string;
+  stepPrompt?: string;
+  planContent: string;
+  priorFeedback?: string[];
 }
 
 /** Build the CLAUDE.md overlay content for a worker's worktree */
@@ -122,6 +133,14 @@ export function buildOverlay(ctx: OverlayContext): string {
     parts.push("### Git Branch");
     parts.push(`Work on branch: \`${ctx.branch}\``);
     parts.push(`Commit message format: conventional commits — \`feat: (${ctx.taskId}) description\`, \`fix: (${ctx.taskId}) description\`, etc. Task ID goes in the subject after the colon, NOT in the scope parentheses.`);
+    parts.push("");
+  }
+
+  if (ctx.reviewFeedback) {
+    parts.push("### Reviewer Feedback");
+    parts.push("The adversarial reviewer rejected your previous plan for the following reasons. Revise your plan to address each point:");
+    parts.push("");
+    parts.push(ctx.reviewFeedback);
     parts.push("");
   }
 
@@ -210,4 +229,128 @@ export function triggerPrompt(taskId: string): string {
 /** Short trigger prompt for resumed tasks */
 export function resumeTriggerPrompt(taskId: string): string {
   return `Resume the task described in your CLAUDE.md instructions. Task ID: ${taskId}. Continue from where the last session left off. Write an updated session summary before finishing.`;
+}
+
+// ---------------------------------------------------------------------------
+// Review sandbox — read-only with narrow write exception
+// ---------------------------------------------------------------------------
+
+/** Build CLAUDE.md overlay for an adversarial reviewer session */
+export function buildReviewOverlay(ctx: ReviewOverlayContext): string {
+  const parts: string[] = [];
+
+  parts.push(`# Review: ${ctx.taskId}`);
+  parts.push(`## ${ctx.title}`);
+  parts.push("");
+
+  parts.push("### Role");
+  parts.push("You are an adversarial reviewer. Your job is to rigorously critique the plan below.");
+  parts.push("You CANNOT modify any code or files except `.grove/review-result.json`.");
+  parts.push("You MUST read the plan carefully, review the codebase for context, and write your verdict.");
+  parts.push("");
+
+  if (ctx.description) {
+    parts.push("### Task Description");
+    parts.push(ctx.description);
+    parts.push("");
+  }
+
+  if (ctx.stepPrompt) {
+    parts.push("### Review Criteria");
+    parts.push(ctx.stepPrompt);
+    parts.push("");
+  }
+
+  parts.push("### Plan Under Review");
+  parts.push("```markdown");
+  parts.push(ctx.planContent);
+  parts.push("```");
+  parts.push("");
+
+  if (ctx.priorFeedback && ctx.priorFeedback.length > 0) {
+    parts.push("### Prior Review History");
+    parts.push("The plan has been revised in response to earlier feedback. Here is the history:");
+    parts.push("");
+    for (let i = 0; i < ctx.priorFeedback.length; i++) {
+      parts.push(`**Round ${i + 1} feedback:**`);
+      parts.push(ctx.priorFeedback[i]);
+      parts.push("");
+    }
+  }
+
+  parts.push("### Output Instructions");
+  parts.push("After your review, write your verdict to `.grove/review-result.json` in the worktree:");
+  parts.push("```json");
+  parts.push('{ "approved": true, "feedback": "Brief explanation of why the plan is approved" }');
+  parts.push("```");
+  parts.push("or:");
+  parts.push("```json");
+  parts.push('{ "approved": false, "feedback": "Detailed feedback explaining what needs to change and why" }');
+  parts.push("```");
+  parts.push("");
+  parts.push("**Rules:**");
+  parts.push("- You must explicitly approve (set `approved: true`) — silence or lack of objection is NOT approval");
+  parts.push("- If rejecting, be specific: name the exact issue and what should change");
+  parts.push("- You may read any file in the codebase to verify claims in the plan");
+  parts.push("- Do NOT modify any file except `.grove/review-result.json`");
+
+  return parts.join("\n");
+}
+
+/** Guard hooks for reviewer: write only to .grove/review-result.json */
+function reviewWriteGuard(worktreePath: string): string {
+  const resultPath = join(worktreePath, ".grove", "review-result.json");
+  return [
+    `RESULT_PATH="${resultPath}"`,
+    'FILE_PATH=$(echo "$CLAUDE_TOOL_INPUT" | grep -o \'"file_path":"[^"]*"\' | head -1 | sed \'s/"file_path":"//;s/"$//\')',
+    '[ -z "$FILE_PATH" ] && exit 0',
+    '[ "$FILE_PATH" = "$RESULT_PATH" ] && exit 0',
+    'echo "BLOCKED: Reviewer can only write to .grove/review-result.json" && exit 2',
+  ].join("; ");
+}
+
+/** Guard hooks for reviewer: block git modifications */
+function reviewBashGuard(): string {
+  const blocked = [...BLOCKED_BASH_PATTERNS, "git add", "git commit", "git checkout", "git rebase", "git merge", "git cherry-pick", "git stash"];
+  const checks = blocked.map(
+    (p) => `echo "$CLAUDE_TOOL_INPUT" | grep -qiF '${p}' && echo "BLOCKED: ${p} is not allowed for reviewers" && exit 2`
+  ).join("; ");
+  return `${checks}; exit 0`;
+}
+
+function buildReviewGuardHooks(worktreePath: string): GuardHookEntry[] {
+  return [
+    { matcher: "Bash", hooks: [{ type: "command", command: reviewBashGuard() }] },
+    { matcher: "Write", hooks: [{ type: "command", command: reviewWriteGuard(worktreePath) }] },
+    { matcher: "Edit", hooks: [{ type: "command", command: 'echo "BLOCKED: Reviewer cannot edit files" && exit 2' }] },
+  ];
+}
+
+/** Deploy review sandbox (stricter than worker) */
+export function deployReviewSandbox(worktreePath: string, ctx: ReviewOverlayContext): void {
+  const claudeDir = join(worktreePath, ".claude");
+  mkdirSync(claudeDir, { recursive: true });
+
+  const settingsPath = join(claudeDir, "settings.local.json");
+  const hooks = buildReviewGuardHooks(worktreePath);
+  const finalSettings = { hooks: { PreToolUse: hooks } };
+
+  writeFileSync(settingsPath, JSON.stringify(finalSettings, null, 2) + "\n");
+
+  const overlayPath = join(claudeDir, "CLAUDE.md");
+  writeFileSync(overlayPath, buildReviewOverlay(ctx) + "\n");
+}
+
+/** Trigger prompt for reviewer sessions */
+export function reviewTriggerPrompt(taskId: string): string {
+  return `Review the plan described in your CLAUDE.md instructions. Task ID: ${taskId}. Read the plan carefully, examine the codebase for context, and write your verdict to .grove/review-result.json.`;
+}
+
+/** Read review feedback from worktree if present */
+export function readReviewFeedback(worktreePath: string): string | null {
+  const feedbackPath = join(worktreePath, ".grove", "review-feedback.md");
+  if (existsSync(feedbackPath)) {
+    try { return readFileSync(feedbackPath, "utf-8"); } catch { return null; }
+  }
+  return null;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -16,6 +16,7 @@ export enum AgentRole {
   Orchestrator = "orchestrator",
   Worker = "worker",
   Evaluator = "evaluator",
+  Reviewer = "reviewer",
 }
 
 export enum EventType {
@@ -41,6 +42,11 @@ export enum EventType {
   EvalStarted = "eval_started",
   EvalPassed = "eval_passed",
   EvalFailed = "eval_failed",
+
+  // Reviewer
+  ReviewStarted = "review_started",
+  ReviewApproved = "review_approved",
+  ReviewRejected = "review_rejected",
 
   // Quality gates
   GatePassed = "gate_passed",
@@ -261,7 +267,7 @@ export interface QualityGatesConfig {
 
 export interface PipelineStep {
   id: string;
-  type: "worker" | "gate" | "merge";
+  type: "worker" | "gate" | "merge" | "review";
   prompt?: string;
   on_success: string;
   on_failure: string;
@@ -308,6 +314,9 @@ export interface EventBusMap {
   "eval:started": { taskId: string; sessionId: string };
   "eval:passed": { taskId: string; feedback?: string };
   "eval:failed": { taskId: string; feedback: string };
+  "review:started": { taskId: string; sessionId: string };
+  "review:approved": { taskId: string; feedback?: string };
+  "review:rejected": { taskId: string; feedback: string };
   "gate:result": { taskId: string; gate: string; passed: boolean; message: string };
   "merge:pr_created": { taskId: string; prNumber: number; prUrl: string };
   "merge:ci_passed": { taskId: string; prNumber: number };
@@ -354,6 +363,16 @@ export const DEFAULT_PATHS: Record<string, PathConfig> = {
       { id: "implement", type: "worker", prompt: "Write the content following the plan." },
       { id: "evaluate", type: "gate", on_failure: "implement" },
       { id: "publish", type: "merge" },
+    ],
+  },
+  adversarial: {
+    description: "Adversarial planning with review loop",
+    steps: [
+      { id: "plan", type: "worker", prompt: "Create a detailed implementation plan for this task. Write it to `.grove/plan.md` in the worktree. Include: approach, files to modify, test strategy, edge cases, and backwards compatibility considerations." },
+      { id: "review", type: "review", prompt: "You are an adversarial reviewer for an open-source framework. Critique this plan for: correctness, backwards compatibility, missing edge cases, test coverage gaps, API design quality. Be rigorous — reject plans that are vague, incomplete, or risk breaking existing behavior.", on_failure: "plan", max_retries: 3 },
+      { id: "implement", type: "worker", prompt: "Implement the approved plan from `.grove/plan.md`. Follow it closely. Commit your changes with conventional commit messages." },
+      { id: "evaluate", type: "gate", on_failure: "implement" },
+      { id: "merge", type: "merge" },
     ],
   },
 };

--- a/tests/agents/reviewer.test.ts
+++ b/tests/agents/reviewer.test.ts
@@ -1,0 +1,273 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { join } from "node:path";
+import { mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { readPlanContent, parseReviewResult, getPriorReviewFeedback } from "../../src/agents/reviewer";
+import { buildReviewOverlay, readReviewFeedback } from "../../src/shared/sandbox";
+import type { ReviewOverlayContext } from "../../src/shared/sandbox";
+import { createTestDb } from "../fixtures/helpers";
+import type { Database } from "../../src/broker/db";
+
+// ---------------------------------------------------------------------------
+// readPlanContent — reads plan from .grove/plan.md or falls back to summary
+// ---------------------------------------------------------------------------
+
+describe("readPlanContent", () => {
+  let worktreePath: string;
+
+  beforeEach(() => {
+    worktreePath = join(tmpdir(), `grove-test-reviewer-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(join(worktreePath, ".grove"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(worktreePath, { recursive: true, force: true });
+  });
+
+  test("reads plan from .grove/plan.md", () => {
+    writeFileSync(join(worktreePath, ".grove", "plan.md"), "# My Plan\n\nDo stuff.");
+    const result = readPlanContent(worktreePath);
+    expect(result).toBe("# My Plan\n\nDo stuff.");
+  });
+
+  test("falls back to session summary when no plan.md", () => {
+    const result = readPlanContent(worktreePath, "Session summary content");
+    expect(result).toBe("Session summary content");
+  });
+
+  test("prefers plan.md over session summary", () => {
+    writeFileSync(join(worktreePath, ".grove", "plan.md"), "Plan from file");
+    const result = readPlanContent(worktreePath, "Session summary");
+    expect(result).toBe("Plan from file");
+  });
+
+  test("returns null when no plan and no summary", () => {
+    const result = readPlanContent(worktreePath);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when plan.md is empty", () => {
+    writeFileSync(join(worktreePath, ".grove", "plan.md"), "  ");
+    const result = readPlanContent(worktreePath);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when session summary is empty", () => {
+    const result = readPlanContent(worktreePath, "  ");
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseReviewResult — reads structured verdict from review-result.json
+// ---------------------------------------------------------------------------
+
+describe("parseReviewResult", () => {
+  let worktreePath: string;
+
+  beforeEach(() => {
+    worktreePath = join(tmpdir(), `grove-test-reviewer-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(join(worktreePath, ".grove"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(worktreePath, { recursive: true, force: true });
+  });
+
+  test("parses approved result", () => {
+    writeFileSync(join(worktreePath, ".grove", "review-result.json"),
+      JSON.stringify({ approved: true, feedback: "Plan looks solid" }));
+
+    const result = parseReviewResult(worktreePath);
+    expect(result).not.toBeNull();
+    expect(result!.approved).toBe(true);
+    expect(result!.feedback).toBe("Plan looks solid");
+  });
+
+  test("parses rejected result", () => {
+    writeFileSync(join(worktreePath, ".grove", "review-result.json"),
+      JSON.stringify({ approved: false, feedback: "Missing error handling for edge case X" }));
+
+    const result = parseReviewResult(worktreePath);
+    expect(result).not.toBeNull();
+    expect(result!.approved).toBe(false);
+    expect(result!.feedback).toBe("Missing error handling for edge case X");
+  });
+
+  test("returns null when file doesn't exist", () => {
+    const result = parseReviewResult(worktreePath);
+    expect(result).toBeNull();
+  });
+
+  test("returns null for invalid JSON", () => {
+    writeFileSync(join(worktreePath, ".grove", "review-result.json"), "not json");
+    const result = parseReviewResult(worktreePath);
+    expect(result).toBeNull();
+  });
+
+  test("coerces truthy approved to boolean", () => {
+    writeFileSync(join(worktreePath, ".grove", "review-result.json"),
+      JSON.stringify({ approved: 1, feedback: "ok" }));
+
+    const result = parseReviewResult(worktreePath);
+    expect(result!.approved).toBe(true);
+  });
+
+  test("provides default feedback when missing", () => {
+    writeFileSync(join(worktreePath, ".grove", "review-result.json"),
+      JSON.stringify({ approved: false }));
+
+    const result = parseReviewResult(worktreePath);
+    expect(result!.feedback).toBe("No feedback provided");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPriorReviewFeedback — reads rejection history from events table
+// ---------------------------------------------------------------------------
+
+describe("getPriorReviewFeedback", () => {
+  let db: Database;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.db;
+    cleanup = t.cleanup;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("returns empty array when no rejections", () => {
+    const result = getPriorReviewFeedback(db, "T-001");
+    expect(result).toEqual([]);
+  });
+
+  test("returns prior rejection feedback in order", () => {
+    db.addEvent("T-001", null, "review_rejected", "Missing tests");
+    db.addEvent("T-001", null, "review_rejected", "API design flaw");
+
+    const result = getPriorReviewFeedback(db, "T-001");
+    expect(result).toEqual(["Missing tests", "API design flaw"]);
+  });
+
+  test("ignores events from other tasks", () => {
+    db.addEvent("T-001", null, "review_rejected", "Task 1 feedback");
+    db.addEvent("T-002", null, "review_rejected", "Task 2 feedback");
+
+    const result = getPriorReviewFeedback(db, "T-001");
+    expect(result).toEqual(["Task 1 feedback"]);
+  });
+
+  test("ignores non-rejection events", () => {
+    db.addEvent("T-001", null, "review_started", "Review started");
+    db.addEvent("T-001", null, "review_rejected", "Real feedback");
+    db.addEvent("T-001", null, "review_approved", "Approved");
+
+    const result = getPriorReviewFeedback(db, "T-001");
+    expect(result).toEqual(["Real feedback"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readReviewFeedback — reads feedback file from worktree
+// ---------------------------------------------------------------------------
+
+describe("readReviewFeedback", () => {
+  let worktreePath: string;
+
+  beforeEach(() => {
+    worktreePath = join(tmpdir(), `grove-test-reviewer-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(join(worktreePath, ".grove"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(worktreePath, { recursive: true, force: true });
+  });
+
+  test("reads feedback when file exists", () => {
+    writeFileSync(join(worktreePath, ".grove", "review-feedback.md"), "Fix the tests");
+    const result = readReviewFeedback(worktreePath);
+    expect(result).toBe("Fix the tests");
+  });
+
+  test("returns null when file doesn't exist", () => {
+    const result = readReviewFeedback(worktreePath);
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildReviewOverlay — CLAUDE.md content for reviewer sessions
+// ---------------------------------------------------------------------------
+
+describe("buildReviewOverlay", () => {
+  const baseCtx: ReviewOverlayContext = {
+    taskId: "T-001",
+    title: "Add feature X",
+    treePath: "/tmp/fake-tree",
+    planContent: "# Plan\n\n1. Add routes\n2. Write tests",
+  };
+
+  test("includes role description", () => {
+    const overlay = buildReviewOverlay(baseCtx);
+    expect(overlay).toContain("adversarial reviewer");
+    expect(overlay).toContain("CANNOT modify any code");
+  });
+
+  test("includes plan content in markdown code block", () => {
+    const overlay = buildReviewOverlay(baseCtx);
+    expect(overlay).toContain("```markdown");
+    expect(overlay).toContain("# Plan");
+    expect(overlay).toContain("1. Add routes");
+  });
+
+  test("includes step prompt as review criteria", () => {
+    const overlay = buildReviewOverlay({
+      ...baseCtx,
+      stepPrompt: "Check for backwards compatibility issues",
+    });
+    expect(overlay).toContain("Review Criteria");
+    expect(overlay).toContain("backwards compatibility");
+  });
+
+  test("includes output instructions for review-result.json", () => {
+    const overlay = buildReviewOverlay(baseCtx);
+    expect(overlay).toContain("review-result.json");
+    expect(overlay).toContain('"approved"');
+  });
+
+  test("includes task description when provided", () => {
+    const overlay = buildReviewOverlay({
+      ...baseCtx,
+      description: "We need to add feature X to the API",
+    });
+    expect(overlay).toContain("Task Description");
+    expect(overlay).toContain("feature X to the API");
+  });
+
+  test("includes prior feedback history", () => {
+    const overlay = buildReviewOverlay({
+      ...baseCtx,
+      priorFeedback: ["Missing error handling", "API naming inconsistent"],
+    });
+    expect(overlay).toContain("Prior Review History");
+    expect(overlay).toContain("Round 1 feedback");
+    expect(overlay).toContain("Missing error handling");
+    expect(overlay).toContain("Round 2 feedback");
+    expect(overlay).toContain("API naming inconsistent");
+  });
+
+  test("omits prior feedback section when empty", () => {
+    const overlay = buildReviewOverlay(baseCtx);
+    expect(overlay).not.toContain("Prior Review History");
+  });
+
+  test("includes explicit approval requirement", () => {
+    const overlay = buildReviewOverlay(baseCtx);
+    expect(overlay).toContain("explicitly approve");
+    expect(overlay).toContain("silence or lack of objection is NOT approval");
+  });
+});

--- a/tests/engine/step-engine.test.ts
+++ b/tests/engine/step-engine.test.ts
@@ -82,6 +82,47 @@ describe("normalizePath", () => {
     expect(result.steps[0].on_failure).toBe("$fail");
   });
 
+  test("string step 'review' infers review type", () => {
+    const result = normalizePath({ description: "test", steps: ["review"] });
+    expect(result.steps[0].type).toBe("review");
+  });
+
+  test("review step on_failure defaults to nearest preceding worker", () => {
+    const result = normalizePath({
+      description: "test",
+      steps: ["plan", "review", "implement"],
+    });
+    expect(result.steps[1].type).toBe("review");
+    expect(result.steps[1].on_failure).toBe("plan");
+  });
+
+  test("review step with no preceding worker defaults on_failure to $fail", () => {
+    const result = normalizePath({ description: "test", steps: ["review"] });
+    expect(result.steps[0].type).toBe("review");
+    expect(result.steps[0].on_failure).toBe("$fail");
+  });
+
+  test("adversarial path normalizes correctly", () => {
+    const result = normalizePath({
+      description: "adversarial",
+      steps: [
+        { plan: { type: "worker", prompt: "Create plan" } },
+        { review: { type: "review", prompt: "Critique plan", on_failure: "plan", max_retries: 3 } },
+        "implement",
+        "evaluate",
+        "merge",
+      ],
+    });
+    expect(result.steps.length).toBe(5);
+    expect(result.steps[0].type).toBe("worker");
+    expect(result.steps[1].type).toBe("review");
+    expect(result.steps[1].on_failure).toBe("plan");
+    expect(result.steps[1].max_retries).toBe(3);
+    expect(result.steps[2].type).toBe("worker");
+    expect(result.steps[3].type).toBe("gate");
+    expect(result.steps[4].type).toBe("merge");
+  });
+
   test("multi-step path wires full chain correctly", () => {
     const result = normalizePath({
       description: "dev",
@@ -140,8 +181,21 @@ const TEST_PATHS = {
 // Bun's mock.module is process-global — we must spread real exports so other
 // test files that import these modules still get the real functions.
 // Only mock modules that would cause side effects (spawning processes).
+// Also add adversarial path for review step tests
+(TEST_PATHS as any).adversarial = {
+  description: "Adversarial planning with review loop",
+  steps: [
+    { id: "plan", type: "worker" as const, on_success: "review", on_failure: "$fail", label: "Plan" },
+    { id: "review", type: "review" as const, on_success: "implement", on_failure: "plan", label: "Review", max_retries: 3 },
+    { id: "implement", type: "worker" as const, on_success: "evaluate", on_failure: "$fail", label: "Implement" },
+    { id: "evaluate", type: "gate" as const, on_success: "merge", on_failure: "implement", label: "Evaluate" },
+    { id: "merge", type: "merge" as const, on_success: "$done", on_failure: "$fail", label: "Merge" },
+  ],
+};
+
 const _realConfig = await import("../../src/broker/config");
 const _realWorker = await import("../../src/agents/worker");
+const _realReviewer = await import("../../src/agents/reviewer");
 
 // config: override configNormalizedPaths only, preserve all other config functions
 mock.module("../../src/broker/config", () => ({
@@ -153,6 +207,12 @@ mock.module("../../src/broker/config", () => ({
 mock.module("../../src/agents/worker", () => ({
   ..._realWorker,
   spawnWorker: mock(() => {}),
+}));
+
+// reviewer: override spawnReviewer to prevent spawning Claude Code processes
+mock.module("../../src/agents/reviewer", () => ({
+  ..._realReviewer,
+  spawnReviewer: mock(() => {}),
 }));
 
 // Dynamic import AFTER mocks are set up
@@ -575,5 +635,134 @@ describe("resumePipeline", () => {
     const resumed = events.find(e => e.event_type === "step_resumed");
     expect(resumed).toBeDefined();
     expect(resumed!.summary).toContain("implement");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Review step pipeline tests (adversarial path)
+// ---------------------------------------------------------------------------
+
+describe("review step transitions", () => {
+  let db: Database;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.db;
+    cleanup = t.cleanup;
+    db.treeUpsert({ id: "tree-1", name: "Test Tree", path: "/tmp/test-tree" });
+    _setDb(db);
+  });
+
+  afterEach(async () => {
+    bus.removeAll();
+    await new Promise((r) => setTimeout(r, 10));
+    cleanup();
+  });
+
+  function createTaskAt(id: string, step: string, stepIndex: number, opts: { retry_count?: number; max_retries?: number; path_name?: string } = {}) {
+    db.run(
+      `INSERT INTO tasks (id, title, status, tree_id, path_name, current_step, step_index, retry_count, max_retries)
+       VALUES (?, ?, 'active', 'tree-1', ?, ?, ?, ?, ?)`,
+      [
+        id,
+        `Task ${id}`,
+        opts.path_name ?? "adversarial",
+        step,
+        stepIndex,
+        opts.retry_count ?? 0,
+        opts.max_retries ?? 2,
+      ],
+    );
+  }
+
+  test("plan step success transitions to review", () => {
+    createTaskAt("T-300", "plan", 0);
+
+    onStepComplete("T-300", "success");
+
+    const updated = db.taskGet("T-300")!;
+    expect(updated.current_step).toBe("review");
+    expect(updated.step_index).toBe(1);
+    expect(updated.status).toBe("active");
+  });
+
+  test("review step success transitions to implement", () => {
+    createTaskAt("T-301", "review", 1);
+
+    onStepComplete("T-301", "success");
+
+    const updated = db.taskGet("T-301")!;
+    expect(updated.current_step).toBe("implement");
+    expect(updated.step_index).toBe(2);
+    expect(updated.status).toBe("active");
+  });
+
+  test("review step failure transitions back to plan (on_failure: plan)", () => {
+    createTaskAt("T-302", "review", 1);
+
+    onStepComplete("T-302", "failure");
+
+    const updated = db.taskGet("T-302")!;
+    // review's on_failure = "plan", so it loops back
+    expect(updated.current_step).toBe("plan");
+    expect(updated.step_index).toBe(0);
+    expect(updated.status).toBe("active");
+  });
+
+  test("review step fatal outcome fails the task immediately", () => {
+    createTaskAt("T-303", "review", 1);
+
+    onStepComplete("T-303", "fatal", "Review loop exhausted — plan not approved");
+
+    const updated = db.taskGet("T-303")!;
+    expect(updated.status).toBe("failed");
+    expect(updated.current_step).toBe("$fail");
+
+    const events = db.eventsByTask("T-303");
+    const failEvent = events.find(e => e.event_type === "task_failed");
+    expect(failEvent).toBeDefined();
+    expect(failEvent!.summary).toContain("plan not approved");
+  });
+
+  test("review failure loops plan→review→plan correctly", () => {
+    createTaskAt("T-304", "plan", 0);
+
+    // plan succeeds → transitions to review
+    onStepComplete("T-304", "success");
+    let updated = db.taskGet("T-304")!;
+    expect(updated.current_step).toBe("review");
+
+    // review fails → transitions back to plan
+    onStepComplete("T-304", "failure");
+    updated = db.taskGet("T-304")!;
+    expect(updated.current_step).toBe("plan");
+
+    // plan succeeds again → transitions to review
+    onStepComplete("T-304", "success");
+    updated = db.taskGet("T-304")!;
+    expect(updated.current_step).toBe("review");
+
+    // review succeeds → transitions to implement
+    onStepComplete("T-304", "success");
+    updated = db.taskGet("T-304")!;
+    expect(updated.current_step).toBe("implement");
+    expect(updated.step_index).toBe(2);
+  });
+
+  test("startPipeline begins adversarial path at plan step", () => {
+    db.run(
+      "INSERT INTO tasks (id, title, status, tree_id, path_name) VALUES (?, ?, 'draft', 'tree-1', 'adversarial')",
+      ["T-305", "Task T-305"],
+    );
+    const task = db.taskGet("T-305")!;
+    const tree = db.treeGet("tree-1")!;
+
+    startPipeline(task, tree, db);
+
+    const updated = db.taskGet("T-305")!;
+    expect(updated.status).toBe("active");
+    expect(updated.current_step).toBe("plan");
+    expect(updated.step_index).toBe(0);
   });
 });


### PR DESCRIPTION
## Feature: adversarial review step type for plan-review loops Issue #78

## Problem

Currently the only step types are `worker` (spawns Claude agent), `gate` (hardcoded quality checks), and `merge`. There's no way to have two agents debate a plan before implementation begins.

For open-source framework repos where plan quality matters (e.g., Wheels), we want an adversarial loop where a planner agent proposes and a reviewer agent critiques until both converge.

## Proposed: `review` step type

A new step type that spawns a Claude agent in a **reviewer role** — read-only, adversarial, focused on critiquing the output of the preceding worker step.

### Path config

```yaml
paths:
  adversarial:
    description: Adversarial planning with review loop
    steps:
      - plan:
          prompt: "Create a detailed implementation plan for this task..."
      - review:
          type: review
          prompt: "You are an adversarial reviewer for an open-source framework. Critique this plan for: correctness, backwards compatibility, missing edge cases, test coverage gaps, API design quality. Be rigorous."
          on_failure: plan
          max_retries: 3
      - implement
      - evaluate
      - merge
```

### How it works

1. **Plan step** (worker): agent creates a plan, writes it to a file (e.g., `.grove/plan.md`)
2. **Review step** (review): spawns a separate Claude agent that:
   - Reads the plan file from the worktree
   - Evaluates it against the review prompt criteria
   - Returns `pass` (plan approved) or `fail` (pushback with structured feedback)
3. **On failure**: feedback from the reviewer is injected into the planner's next prompt
   - Planner sees: "The reviewer rejected your plan for these reasons: [feedback]. Revise."
4. **On success**: proceeds to `implement` — the approved plan serves as the spec
5. **Max retries**: after N loops without convergence, task fails with "plan not approved"

### Key design decisions

- **Reviewer is a separate agent** — models are poor self-critics, so the reviewer must be a different Claude session than the planner
- **Feedback threading** — each loop iteration appends the reviewer's feedback to the planner's context, building a conversation history
- **Convergence** — the reviewer must explicitly approve (not just "no objections") to prevent false convergence
- **Read-only** — reviewer cannot modify files, only read and critique

### Implementation sketch

1. Add `review` to `executeStep` in `step-engine.ts` alongside `worker`, `gate`, `merge`
2. Create `src/agents/reviewer.ts` — spawns Claude with review-specific prompt + plan context
3. Reviewer output is structured: `{ approved: boolean, feedback: string }`
4. `onStepComplete` for review steps: if failure, inject feedback into the next worker prompt via `buildRetryPrompt` equivalent
5. The plan file path convention: `.grove/plan.md` in the worktree

### Use case

Wheels (CFWheels framework) — open-source CFML framework where:
- Backwards compatibility is critical
- API design affects hundreds of downstream projects
- Plan quality prevents expensive implement-then-revert cycles
- Multiple engine adapters (Lucee, Adobe, BoxLang) mean changes have wide blast radius

## Open questions

- Should the reviewer have access to the full codebase or just the plan file?
- Should there be a structured plan format (sections, checklist) or freeform markdown?
- Can we reuse the evaluator agent infrastructure or does review need its own agent type?
- Should the plan-review conversation history persist as a viewable artifact in the UI?

**Task:** W-038
**Path:** development
**Cost:** $0.00
**Files changed:** 11

### Quality Gates
- commits: passed — 1 commit on branch
- tests: passed — No test command configured — skipped
- diff_size: passed — 1053 lines changed

Closes #78

---
*Created by [Grove](https://grove.cloud)*