### PR TITLE
feat: (W-050) bug: grove tree add doesn't detect GitHub remote for some...

### DIFF
--- a/src/broker/server.ts
+++ b/src/broker/server.ts
@@ -9,6 +9,7 @@ import { startSeedSession, sendSeedMessage, stopSeedSession, isSeedSessionActive
 import { ActivityRingBuffer, type ActivityEvent } from "./ring-buffer";
 import { BatchedBroadcaster } from "./batched-broadcaster";
 import { detectCycle, type DagEdge } from "../batch/dag";
+import { detectGithubRemote } from "../shared/github";
 
 export interface ServerOptions {
   db: Database;
@@ -438,11 +439,12 @@ async function handleApi(
       if (!body.path) return json({ error: "path required" }, 400);
       const { basename } = await import("node:path");
       const id = body.id ?? basename(body.path).toLowerCase().replace(/[^a-z0-9-]/g, "-");
+      const github = body.github ?? detectGithubRemote(body.path) ?? undefined;
       db.treeUpsert({
         id,
         name: id,
         path: body.path,
-        github: body.github,
+        github,
         branch_prefix: body.branch_prefix ?? "grove/",
       });
       return json(db.treeGet(id), 201);

--- a/src/cli/commands/trees.ts
+++ b/src/cli/commands/trees.ts
@@ -4,6 +4,7 @@ import { resolve, basename } from "node:path";
 import pc from "picocolors";
 import { loadConfig, configTrees, configSet, reloadConfig } from "../../broker/config";
 import { expandHome } from "../../shared/worktree";
+import { detectGithubRemote } from "../../shared/github";
 
 export async function run(args: string[]) {
   // grove tree add <path> [--github org/repo] [--name name]
@@ -70,15 +71,7 @@ async function addTree(args: string[]) {
   // Auto-detect GitHub remote if not provided
   let detectedGithub = github;
   if (!detectedGithub) {
-    const result = Bun.spawnSync(["git", "-C", treePath, "remote", "get-url", "origin"]);
-    if (result.exitCode === 0) {
-      const url = result.stdout.toString().trim();
-      // Parse github.com:org/repo.git or https://github.com/org/repo.git
-      const match = url.match(/github\.com[:/]([^/]+\/[^/.]+)/);
-      if (match) {
-        detectedGithub = match[1];
-      }
-    }
+    detectedGithub = detectGithubRemote(treePath) ?? undefined;
   }
 
   // Check if tree already exists

--- a/src/shared/github.ts
+++ b/src/shared/github.ts
@@ -1,0 +1,12 @@
+/** Parse org/repo from a GitHub remote URL. Returns null if not a GitHub URL. */
+export function parseGithubRemote(url: string): string | null {
+  const match = url.match(/github\.com[:/]([^/]+\/[^/]+?)(?:\.git)?\s*$/);
+  return match ? match[1] : null;
+}
+
+/** Run `git remote get-url origin` at the given path and parse the GitHub org/repo. */
+export function detectGithubRemote(path: string): string | null {
+  const result = Bun.spawnSync(["git", "-C", path, "remote", "get-url", "origin"]);
+  if (result.exitCode !== 0) return null;
+  return parseGithubRemote(result.stdout.toString().trim());
+}

--- a/tests/shared/github-url.test.ts
+++ b/tests/shared/github-url.test.ts
@@ -1,0 +1,50 @@
+import { describe, test, expect } from "bun:test";
+import { parseGithubRemote, detectGithubRemote } from "../../src/shared/github";
+
+describe("parseGithubRemote", () => {
+  test("parses HTTPS URL with .git suffix", () => {
+    expect(parseGithubRemote("https://github.com/paiindustries/titan.git")).toBe("paiindustries/titan");
+  });
+
+  test("parses HTTPS URL without .git suffix", () => {
+    expect(parseGithubRemote("https://github.com/org/repo")).toBe("org/repo");
+  });
+
+  test("parses SSH URL", () => {
+    expect(parseGithubRemote("git@github.com:bpamiri/grove.git")).toBe("bpamiri/grove");
+  });
+
+  test("parses SSH protocol URL", () => {
+    expect(parseGithubRemote("ssh://git@github.com/org/repo.git")).toBe("org/repo");
+  });
+
+  test("handles repo names with dots", () => {
+    expect(parseGithubRemote("https://github.com/wheels-dev/wheels.dev.git")).toBe("wheels-dev/wheels.dev");
+  });
+
+  test("handles repo names with multiple dots", () => {
+    expect(parseGithubRemote("https://github.com/org/my.dotted.repo.git")).toBe("org/my.dotted.repo");
+  });
+
+  test("returns null for non-GitHub URLs", () => {
+    expect(parseGithubRemote("https://gitlab.com/org/repo.git")).toBeNull();
+  });
+
+  test("returns null for empty string", () => {
+    expect(parseGithubRemote("")).toBeNull();
+  });
+});
+
+describe("detectGithubRemote", () => {
+  test("detects GitHub remote from a real git repo", () => {
+    // Use the grove repo itself as a test subject
+    const result = detectGithubRemote(import.meta.dir);
+    // This test runs inside the grove repo, so it should detect bpamiri/grove
+    expect(result).toBe("bpamiri/grove");
+  });
+
+  test("returns null for non-git directory", () => {
+    const result = detectGithubRemote("/tmp");
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## bug: grove tree add doesn't detect GitHub remote for some repos Issue #105

## Description

`grove tree add /Users/peter/GitHub/paiindustries/titan` doesn't recognize the repo as a GitHub repo. Expected it to auto-detect the GitHub remote (`paiindustries/titan`).

## Steps to reproduce

1. `grove tree add ~/GitHub/paiindustries/titan`
2. `grove trees` — tree shows with `github: null`

## Expected

Auto-detect `paiindustries/titan` from the git remote URL (same as other repos).

## Environment

- Grove v0.1.22
- Repo has a valid `origin` remote pointing to `github.com/paiindustries/titan`

**Task:** W-050
**Path:** development
**Cost:** $0.00
**Files changed:** 4

### Quality Gates
- commits: passed — 1 commit on branch
- tests: passed — No test command configured — skipped
- diff_size: passed — 77 lines changed

Closes #105

---
*Created by [Grove](https://grove.cloud)*