### PR TITLE
feat: (W-051) feat: WorkerActivityFeed — live SAP event stream in task...

### DIFF
--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import type { Task, Tree } from "../hooks/useTasks";
 import Pipeline from "./Pipeline";
-import type { PathStep } from "./Pipeline";
 import TaskForm from "./TaskForm";
 import SeedChat from "./SeedChat";
 import type { Seed, SeedMessage } from "../hooks/useSeed";
-import ActivityIndicator from "./ActivityIndicator";
+import WorkerActivityFeed from "./WorkerActivityFeed";
 import VerdictPanel from "./VerdictPanel";
 
 interface PathInfo {
@@ -92,10 +91,14 @@ export default function TaskDetail({ task, activityLog, steps, send, trees, path
         <Pipeline task={task} steps={steps} />
       </div>
 
-      {/* Activity feed — live when running, historical for completed/failed */}
-      {((activityLog ?? []).length > 0 || (task.status === "active" && !task.paused)) && (
-        <ActivityFeed log={activityLog ?? []} live={task.status === "active" && !task.paused} since={task.started_at} />
-      )}
+      {/* Activity feed — live when running, summary when complete, idle when draft/queued */}
+      <WorkerActivityFeed
+        log={activityLog ?? []}
+        taskStatus={task.status}
+        paused={!!task.paused}
+        since={task.started_at}
+        costUsd={task.cost_usd}
+      />
 
       {/* Description */}
       {task.description && (
@@ -241,101 +244,6 @@ export default function TaskDetail({ task, activityLog, steps, send, trees, path
       </div>
     </div>
   );
-}
-
-function ActivityFeed({ log, live, since }: { log: Array<{ ts: number; msg: string; kind?: string }>; live?: boolean; since?: string | null }) {
-  const bottomRef = useRef<HTMLDivElement>(null);
-  const [paused, setPaused] = useState(false);
-  const [pinnedLength, setPinnedLength] = useState(0);
-
-  useEffect(() => {
-    if (!paused) {
-      bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-    }
-  }, [log.length, paused]);
-
-  const displayLog = paused ? log.slice(0, pinnedLength) : log;
-
-  return (
-    <div>
-      <div className="flex justify-between items-center mb-1.5">
-        <Label>{live ? "Live Activity" : "Activity Log"}</Label>
-        {live && log.length > 0 && (
-          <button
-            onClick={() => {
-              if (!paused) setPinnedLength(log.length);
-              setPaused(!paused);
-            }}
-            className="text-[10px] px-2 py-0.5 rounded bg-zinc-800 text-zinc-400 hover:bg-zinc-700"
-          >
-            {paused ? `Resume (${log.length - pinnedLength} new)` : "Pause"}
-          </button>
-        )}
-      </div>
-      <div className="bg-zinc-950 border border-zinc-800 rounded-lg p-2 max-h-48 overflow-y-auto font-mono text-[11px] leading-relaxed">
-        {displayLog.length === 0 && live && (
-          <div className="text-blue-400/70 text-center py-3">
-            <ActivityIndicator since={since} label="Waiting for activity" size="md" />
-          </div>
-        )}
-        {displayLog.map((entry, i) => {
-          const time = new Date(entry.ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
-          return (
-            <div key={i} className="flex gap-2 hover:bg-zinc-900/50 px-1 rounded group">
-              <span className="text-zinc-600 flex-shrink-0">{time}</span>
-              <span className={`${activityColor(entry.msg, entry.kind)} break-all`}>
-                {entry.msg.length > 200 ? (
-                  <TruncatedText text={entry.msg} maxLength={200} />
-                ) : entry.msg}
-              </span>
-            </div>
-          );
-        })}
-        {displayLog.length > 0 && live && !paused && (
-          <div className="text-blue-400/60 px-1 pt-1">
-            <ActivityIndicator since={displayLog[displayLog.length - 1]?.ts} />
-          </div>
-        )}
-        <div ref={bottomRef} />
-      </div>
-    </div>
-  );
-}
-
-function TruncatedText({ text, maxLength }: { text: string; maxLength: number }) {
-  const [expanded, setExpanded] = useState(false);
-  if (expanded) {
-    return (
-      <span>
-        {text}{" "}
-        <button onClick={() => setExpanded(false)} className="text-blue-400/60 hover:text-blue-400">less</button>
-      </span>
-    );
-  }
-  return (
-    <span>
-      {text.slice(0, maxLength)}
-      <button onClick={() => setExpanded(true)} className="text-blue-400/60 hover:text-blue-400">...more</button>
-    </span>
-  );
-}
-
-function activityColor(msg: string, kind?: string): string {
-  if (kind === "thinking") return "text-purple-400/70 italic";
-  if (kind === "text") return "text-zinc-300/80";
-  if (kind === "tool") {
-    if (msg.startsWith("Read") || msg.startsWith("Grep") || msg.startsWith("Glob")) return "text-zinc-400";
-    if (msg.startsWith("Edit") || msg.startsWith("Write")) return "text-amber-400";
-    if (msg.startsWith("Bash")) return "text-cyan-400";
-    return "text-blue-400";
-  }
-  // Legacy worker:activity messages (no kind)
-  if (msg.startsWith("thinking:")) return "text-purple-400/70 italic";
-  if (msg.startsWith("Read") || msg.startsWith("Grep") || msg.startsWith("Glob")) return "text-zinc-400";
-  if (msg.startsWith("Edit") || msg.startsWith("Write")) return "text-amber-400";
-  if (msg.startsWith("Bash")) return "text-cyan-400";
-  if (!msg.includes(":") || msg.indexOf(":") > 20) return "text-zinc-300/80";
-  return "text-zinc-300";
 }
 
 function Field({ label, value, mono }: { label: string; value: string; mono?: boolean }) {

--- a/web/src/components/WorkerActivityFeed.tsx
+++ b/web/src/components/WorkerActivityFeed.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useRef, useState } from "react";
+import ActivityIndicator from "./ActivityIndicator";
+
+export interface ActivityEntry {
+  ts: number;
+  msg: string;
+  kind?: string;
+}
+
+interface Props {
+  log: ActivityEntry[];
+  taskStatus: string;
+  paused?: boolean;
+  since?: string | null;
+  costUsd?: number;
+}
+
+/**
+ * Live scrolling feed of SAP agent events (tool_use, thinking, text, cost).
+ * Renders in three modes:
+ *  - idle: task is draft/queued — shows "No worker active"
+ *  - live: task is active — auto-scrolling feed with pause/resume
+ *  - completed: task is completed/failed — collapsed summary, expandable
+ */
+export default function WorkerActivityFeed({ log, taskStatus, paused: taskPaused, since, costUsd }: Props) {
+  const isLive = taskStatus === "active" && !taskPaused;
+  const isIdle = taskStatus === "draft" || taskStatus === "queued" || taskStatus === "waiting" || taskStatus === "cancelled";
+  const isComplete = taskStatus === "completed" || taskStatus === "failed";
+
+  // Idle state
+  if (isIdle) {
+    return (
+      <Section label="Activity">
+        <div className="bg-zinc-950 border border-zinc-800 rounded-lg p-4 text-center">
+          <span className="text-zinc-500 text-xs">No worker active</span>
+        </div>
+      </Section>
+    );
+  }
+
+  // Completed/failed — collapsed summary
+  if (isComplete && log.length > 0) {
+    return <CompletedSummary log={log} taskStatus={taskStatus} costUsd={costUsd} />;
+  }
+
+  // Live (or paused active task, or completed with no log)
+  return <LiveFeed log={log} live={isLive} since={since} />;
+}
+
+// ---------------------------------------------------------------------------
+// Live feed with auto-scroll and pause/resume
+// ---------------------------------------------------------------------------
+
+function LiveFeed({ log, live, since }: { log: ActivityEntry[]; live: boolean; since?: string | null }) {
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const [paused, setPaused] = useState(false);
+  const [pinnedLength, setPinnedLength] = useState(0);
+
+  useEffect(() => {
+    if (!paused) {
+      bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [log.length, paused]);
+
+  const displayLog = paused ? log.slice(0, pinnedLength) : log;
+
+  return (
+    <Section label={live ? "Live Activity" : "Activity Log"}>
+      <div className="flex justify-end -mt-6 mb-1">
+        {live && log.length > 0 && (
+          <button
+            onClick={() => {
+              if (!paused) setPinnedLength(log.length);
+              setPaused(!paused);
+            }}
+            className="text-[10px] px-2 py-0.5 rounded bg-zinc-800 text-zinc-400 hover:bg-zinc-700"
+          >
+            {paused ? `Resume (${log.length - pinnedLength} new)` : "Pause"}
+          </button>
+        )}
+      </div>
+      <div className="bg-zinc-950 border border-zinc-800 rounded-lg p-2 max-h-48 overflow-y-auto font-mono text-[11px] leading-relaxed">
+        {displayLog.length === 0 && live && (
+          <div className="text-blue-400/70 text-center py-3">
+            <ActivityIndicator since={since} label="Waiting for activity" size="md" />
+          </div>
+        )}
+        {displayLog.map((entry, i) => (
+          <FeedRow key={i} entry={entry} />
+        ))}
+        {displayLog.length > 0 && live && !paused && (
+          <div className="text-blue-400/60 px-1 pt-1">
+            <ActivityIndicator since={displayLog[displayLog.length - 1]?.ts} />
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+    </Section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Completed summary — collapsed by default, expandable
+// ---------------------------------------------------------------------------
+
+function CompletedSummary({ log, taskStatus, costUsd }: { log: ActivityEntry[]; taskStatus: string; costUsd?: number }) {
+  const [expanded, setExpanded] = useState(false);
+  const lastEntries = log.slice(-3);
+  const statusColor = taskStatus === "completed" ? "text-emerald-400" : "text-red-400";
+
+  return (
+    <Section label="Activity">
+      <div className="bg-zinc-950 border border-zinc-800 rounded-lg">
+        {/* Summary header — always visible */}
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="w-full text-left px-3 py-2 flex justify-between items-center hover:bg-zinc-900/50 rounded-lg"
+        >
+          <div className="text-[11px] font-mono text-zinc-400 truncate flex-1">
+            {lastEntries.map((e, i) => (
+              <span key={i}>
+                {i > 0 && <span className="text-zinc-600 mx-1">→</span>}
+                <span className={activityColor(e.msg, e.kind)}>{truncate(e.msg, 40)}</span>
+              </span>
+            ))}
+          </div>
+          <div className="flex items-center gap-2 flex-shrink-0 ml-2">
+            {costUsd != null && costUsd > 0 && (
+              <span className="text-emerald-400 text-[10px]">${costUsd.toFixed(2)}</span>
+            )}
+            <span className={`text-[10px] ${statusColor}`}>
+              {taskStatus} · {log.length} events
+            </span>
+            <span className="text-zinc-600 text-[10px]">{expanded ? "▲" : "▼"}</span>
+          </div>
+        </button>
+
+        {/* Expanded full log */}
+        {expanded && (
+          <div className="border-t border-zinc-800 p-2 max-h-48 overflow-y-auto font-mono text-[11px] leading-relaxed">
+            {log.map((entry, i) => (
+              <FeedRow key={i} entry={entry} />
+            ))}
+          </div>
+        )}
+      </div>
+    </Section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared sub-components
+// ---------------------------------------------------------------------------
+
+function FeedRow({ entry }: { entry: ActivityEntry }) {
+  const time = new Date(entry.ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+  return (
+    <div className="flex gap-2 hover:bg-zinc-900/50 px-1 rounded group">
+      <span className="text-zinc-600 flex-shrink-0">{time}</span>
+      <span className={`${activityColor(entry.msg, entry.kind)} break-all`}>
+        {entry.msg.length > 200 ? (
+          <TruncatedText text={entry.msg} maxLength={200} />
+        ) : entry.msg}
+      </span>
+    </div>
+  );
+}
+
+function TruncatedText({ text, maxLength }: { text: string; maxLength: number }) {
+  const [expanded, setExpanded] = useState(false);
+  if (expanded) {
+    return (
+      <span>
+        {text}{" "}
+        <button onClick={() => setExpanded(false)} className="text-blue-400/60 hover:text-blue-400">less</button>
+      </span>
+    );
+  }
+  return (
+    <span>
+      {text.slice(0, maxLength)}
+      <button onClick={() => setExpanded(true)} className="text-blue-400/60 hover:text-blue-400">...more</button>
+    </span>
+  );
+}
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="text-zinc-500 text-xs uppercase mb-1.5">{label}</div>
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Color mapping
+// ---------------------------------------------------------------------------
+
+export function activityColor(msg: string, kind?: string): string {
+  if (kind === "thinking") return "text-purple-400/70 italic";
+  if (kind === "text") return "text-zinc-300/80";
+  if (kind === "cost") return "text-emerald-400";
+  if (kind === "tool") {
+    if (msg.startsWith("Read") || msg.startsWith("Grep") || msg.startsWith("Glob")) return "text-zinc-400";
+    if (msg.startsWith("Edit") || msg.startsWith("Write")) return "text-amber-400";
+    if (msg.startsWith("Bash")) return "text-cyan-400";
+    return "text-blue-400";
+  }
+  // Legacy worker:activity messages (no kind)
+  if (msg.startsWith("thinking:")) return "text-purple-400/70 italic";
+  if (msg.startsWith("Read") || msg.startsWith("Grep") || msg.startsWith("Glob")) return "text-zinc-400";
+  if (msg.startsWith("Edit") || msg.startsWith("Write")) return "text-amber-400";
+  if (msg.startsWith("Bash")) return "text-cyan-400";
+  if (!msg.includes(":") || msg.indexOf(":") > 20) return "text-zinc-300/80";
+  return "text-zinc-300";
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function truncate(str: string, max: number): string {
+  return str.length > max ? str.slice(0, max) + "…" : str;
+}

--- a/web/src/hooks/useTasks.ts
+++ b/web/src/hooks/useTasks.ts
@@ -62,6 +62,7 @@ export interface Status {
 // Activity messages per task (transient, not from DB)
 const taskActivity = new Map<string, string>();
 const taskActivityLog = new Map<string, Array<{ ts: number; msg: string; kind?: string }>>();
+const activityLogFetched = new Set<string>();
 const MAX_LOG_ENTRIES = 200;
 
 export function useTasks() {
@@ -156,6 +157,19 @@ export function useTasks() {
         setTasks(prev => [...prev]);
         break;
       }
+      case "agent:cost": {
+        const tid = msg.data.taskId;
+        if (tid === "orchestrator") break;
+        const costMsg = `cost: $${msg.data.costUsd?.toFixed(2) ?? "?"} (${msg.data.tokens ?? 0} tokens)`;
+        if (!taskActivityLog.has(tid)) taskActivityLog.set(tid, []);
+        const clog = taskActivityLog.get(tid)!;
+        clog.push({ ts: msg.data.ts ?? Date.now(), msg: costMsg, kind: "cost" });
+        if (clog.length > MAX_LOG_ENTRIES) clog.shift();
+        setTasks(prev => [...prev]);
+        // Also refresh to update cost_usd on the task object
+        refresh();
+        break;
+      }
       case "worker:spawned":
       case "worker:ended":
       case "cost:updated":
@@ -170,19 +184,26 @@ export function useTasks() {
 
   /** Fetch activity from live ring buffer first, then fall back to historical log */
   const loadActivityLog = useCallback(async (taskId: string) => {
-    if (taskActivityLog.has(taskId) && taskActivityLog.get(taskId)!.length > 0) return;
+    if (activityLogFetched.has(taskId)) return;
+    activityLogFetched.add(taskId);
     try {
       // Try live ring buffer first (for active tasks)
-      const liveEntries = await api<Array<{ type: string; taskId: string; tool?: string; input?: string; snippet?: string; content?: string; ts?: number }>>(`/api/tasks/${taskId}/activity/live`);
+      const liveEntries = await api<Array<{ type: string; taskId: string; tool?: string; input?: string; snippet?: string; content?: string; costUsd?: number; tokens?: number; ts?: number }>>(`/api/tasks/${taskId}/activity/live`);
       if (liveEntries.length > 0) {
-        const log = liveEntries.map(e => {
+        const fetched = liveEntries.map(e => {
           const ts = e.ts ?? Date.now();
           if (e.type === "agent:tool_use") return { ts, msg: `${e.tool}: ${e.input}`, kind: "tool" as const };
           if (e.type === "agent:thinking") return { ts, msg: `thinking: ${e.snippet}`, kind: "thinking" as const };
           if (e.type === "agent:text") return { ts, msg: e.content ?? "", kind: "text" as const };
+          if (e.type === "agent:cost") return { ts, msg: `cost: $${e.costUsd?.toFixed(2) ?? "?"} (${e.tokens ?? 0} tokens)`, kind: "cost" as const };
           return { ts, msg: `${e.type}` };
         });
-        taskActivityLog.set(taskId, log);
+        // Merge with any live WS events already in the log, deduplicating by timestamp
+        const existing = taskActivityLog.get(taskId) ?? [];
+        const existingTs = new Set(existing.map(e => e.ts));
+        const merged = [...fetched.filter(e => !existingTs.has(e.ts)), ...existing].sort((a, b) => a.ts - b.ts);
+        if (merged.length > MAX_LOG_ENTRIES) merged.splice(0, merged.length - MAX_LOG_ENTRIES);
+        taskActivityLog.set(taskId, merged);
         setTasks(prev => [...prev]);
         return;
       }


### PR DESCRIPTION
## feat: WorkerActivityFeed — live SAP event stream in task detail GUI Issue #124

## Problem

The backend streams fine-grained SAP events (`agent:tool_use`, `agent:thinking`, `agent:text`, `agent:cost`) from workers in real-time. The server broadcasts them over WebSocket. The ring buffer (`ring-buffer.ts`) caches the last 100 events for late-joining clients. But the GUI's `TaskDetail.tsx` shows activity as a simple text log parsed from JSONL files — there's no component that renders the live SAP stream.

## Proposed Solution

A `WorkerActivityFeed.tsx` component that:

- Subscribes to `agent:tool_use`, `agent:thinking`, `agent:text`, `agent:cost` WebSocket events filtered by taskId
- Renders a live scrolling feed with timestamps (HH:MM:SS)
- Color-coded by event type (tool use = blue, thinking = gray, text = white, cost = green)
- Truncated long inputs expandable on click
- Auto-scroll with pin-to-bottom toggle
- Pause/resume streaming (buffer while paused)
- Ring buffer catch-up on mount (GET `/api/tasks/:id/activity/live`)
- Collapses to last-activity summary when task completes
- Shows "No worker active" when task is idle/draft/queued

Wire into `TaskDetail.tsx` when task status is `active`.

## Why This Matters

This is the core UX of an orchestrator — watching agents think, read files, edit code, and run tests in real-time. The backend is fully ready; the frontend just needs to consume it.

## Context

- SAP events defined in `src/shared/protocol.ts`
- Worker emits events in `src/agents/worker.ts` (`monitorWorker()`)
- Server broadcasts via WebSocket in `src/broker/server.ts`
- Ring buffer in `src/broker/ring-buffer.ts`
- Catch-up endpoint: `GET /api/tasks/:id/activity/live`

**Task:** W-051
**Path:** development
**Cost:** $0.00
**Files changed:** 3

### Quality Gates
- commits: passed — 1 commit on branch
- tests: passed — No test command configured — skipped
- diff_size: passed — 366 lines changed

Closes #124

---
*Delivered by [Grove](https://grove.cloud)*