### PR TITLE
feat: (W-053) feat: per-tree worker_instructions in grove.yaml Issue #126

### DIFF
--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -87,6 +87,7 @@ export function spawnWorker(task: Task, tree: Tree, db: Database, logDir: string
     treePath: tree.path,
     branch,
     pathName: task.path_name,
+    workerInstructions: treeConfig.worker_instructions,
     sessionSummary: priorSummary,
     filesModified: task.files_modified,
     stepPrompt,

--- a/src/broker/index.ts
+++ b/src/broker/index.ts
@@ -67,7 +67,7 @@ export async function startBroker(): Promise<BrokerInfo> {
       path: treeConfig.path,
       github: treeConfig.github,
       branch_prefix: treeConfig.branch_prefix ?? config.settings.branch_prefix,
-      config: JSON.stringify({ quality_gates: treeConfig.quality_gates, default_branch: treeConfig.default_branch, default_path: treeConfig.default_path }),
+      config: JSON.stringify({ quality_gates: treeConfig.quality_gates, default_branch: treeConfig.default_branch, default_path: treeConfig.default_path, worker_instructions: treeConfig.worker_instructions }),
     });
   }
 

--- a/src/shared/sandbox.ts
+++ b/src/shared/sandbox.ts
@@ -40,6 +40,7 @@ export interface OverlayContext {
   treePath: string;
   branch?: string | null;
   pathName?: string;
+  workerInstructions?: string | null;
   sessionSummary?: string | null;
   filesModified?: string | null;
   stepPrompt?: string;
@@ -91,6 +92,12 @@ export function buildOverlay(ctx: OverlayContext): string {
   if (ctx.pathName) {
     parts.push("### Workflow");
     parts.push(`This task follows the **${ctx.pathName}** path.`);
+    parts.push("");
+  }
+
+  if (ctx.workerInstructions) {
+    parts.push("### Worker Instructions");
+    parts.push(ctx.workerInstructions);
     parts.push("");
   }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -175,6 +175,7 @@ export interface TreeConfig {
   branch_prefix?: string;
   default_branch?: string; // e.g. "develop", "main" — branch to fork worktrees from
   default_path?: string;   // e.g. "adversarial", "content" — default path for new tasks in this tree
+  worker_instructions?: string; // multiline string injected into worker CLAUDE.md overlay
   quality_gates?: QualityGatesConfig;
 }
 

--- a/tests/shared/sandbox.test.ts
+++ b/tests/shared/sandbox.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect } from "bun:test";
+import { buildOverlay } from "../../src/shared/sandbox";
+import type { OverlayContext } from "../../src/shared/sandbox";
+
+// ---------------------------------------------------------------------------
+// buildOverlay — CLAUDE.md content for worker sessions
+// ---------------------------------------------------------------------------
+
+const baseCtx: OverlayContext = {
+  taskId: "T-001",
+  title: "Add feature X",
+  treePath: "/tmp/fake-tree",
+};
+
+describe("buildOverlay", () => {
+  test("includes task header and title", () => {
+    const overlay = buildOverlay(baseCtx);
+    expect(overlay).toContain("# Task: T-001");
+    expect(overlay).toContain("## Add feature X");
+  });
+
+  test("includes strategy section", () => {
+    const overlay = buildOverlay(baseCtx);
+    expect(overlay).toContain("### Strategy");
+  });
+
+  test("includes description when provided", () => {
+    const overlay = buildOverlay({ ...baseCtx, description: "Build the widget" });
+    expect(overlay).toContain("### Description");
+    expect(overlay).toContain("Build the widget");
+  });
+
+  test("omits description when null", () => {
+    const overlay = buildOverlay({ ...baseCtx, description: null });
+    expect(overlay).not.toContain("### Description");
+  });
+
+  // ---------------------------------------------------------------------------
+  // worker_instructions
+  // ---------------------------------------------------------------------------
+
+  test("includes worker instructions when provided", () => {
+    const overlay = buildOverlay({
+      ...baseCtx,
+      workerInstructions: "Run tests with: box testbox run\nAlways restart after config changes.",
+    });
+    expect(overlay).toContain("### Worker Instructions");
+    expect(overlay).toContain("Run tests with: box testbox run");
+    expect(overlay).toContain("Always restart after config changes.");
+  });
+
+  test("omits worker instructions when null", () => {
+    const overlay = buildOverlay({ ...baseCtx, workerInstructions: null });
+    expect(overlay).not.toContain("### Worker Instructions");
+  });
+
+  test("omits worker instructions when undefined", () => {
+    const overlay = buildOverlay(baseCtx);
+    expect(overlay).not.toContain("### Worker Instructions");
+  });
+
+  test("omits worker instructions when empty string", () => {
+    const overlay = buildOverlay({ ...baseCtx, workerInstructions: "" });
+    expect(overlay).not.toContain("### Worker Instructions");
+  });
+
+  test("worker instructions appear after workflow and before strategy", () => {
+    const overlay = buildOverlay({
+      ...baseCtx,
+      pathName: "development",
+      workerInstructions: "Use uv run pytest",
+    });
+    const workflowIdx = overlay.indexOf("### Workflow");
+    const instructionsIdx = overlay.indexOf("### Worker Instructions");
+    const strategyIdx = overlay.indexOf("### Strategy");
+
+    expect(workflowIdx).toBeGreaterThan(-1);
+    expect(instructionsIdx).toBeGreaterThan(workflowIdx);
+    expect(strategyIdx).toBeGreaterThan(instructionsIdx);
+  });
+
+  test("worker instructions appear before strategy when no workflow", () => {
+    const overlay = buildOverlay({
+      ...baseCtx,
+      workerInstructions: "Use uv run pytest",
+    });
+    const instructionsIdx = overlay.indexOf("### Worker Instructions");
+    const strategyIdx = overlay.indexOf("### Strategy");
+
+    expect(instructionsIdx).toBeGreaterThan(-1);
+    expect(strategyIdx).toBeGreaterThan(instructionsIdx);
+  });
+
+  test("preserves multiline worker instructions", () => {
+    const instructions = `This is a CFWheels CFML application running on CommandBox.
+Run tests with: box testbox run
+Always restart the server after modifying config: box server restart`;
+
+    const overlay = buildOverlay({
+      ...baseCtx,
+      workerInstructions: instructions,
+    });
+    expect(overlay).toContain(instructions);
+  });
+});


### PR DESCRIPTION
## feat: per-tree worker_instructions in grove.yaml Issue #126

## Problem

Workers get a CLAUDE.md overlay with task metadata and the repo's root CLAUDE.md appended as context. But there's no way for the Grove operator to provide tree-specific worker instructions beyond what's in the repo's CLAUDE.md (which the contributor may not control).

Different repos need different worker behavior — a CFML codebase needs "run \`box server start\` before testing," a Python repo needs "use \`uv run pytest\`."

## Proposed Solution

A `worker_instructions` field per tree in `grove.yaml` (multiline string), injected into the worker's CLAUDE.md overlay after the task description and before the strategy section.

```yaml
trees:
  titan:
    path: /Users/peter/GitHub/paiindustries/titan
    worker_instructions: |
      This is a CFWheels CFML application running on CommandBox.
      Run tests with: box testbox run
      Always restart the server after modifying config: box server restart
```

## Why This Matters

Lets the Grove operator shape worker behavior per tree without modifying the repo's own CLAUDE.md. Separates orchestration concerns (how Grove should work with this repo) from repo concerns (how developers should work with this repo).

## Context

- Overlay built in `src/shared/sandbox.ts` (`buildOverlay()`)
- Tree config in `src/broker/config.ts`
- Types in `src/shared/types.ts` (Tree interface)

**Task:** W-053
**Path:** development
**Cost:** $0.00
**Files changed:** 8

### Quality Gates
- commits: passed — 1 commit on branch
- tests: passed — No test command configured — skipped
- diff_size: passed — 116 lines changed

Closes #126

---
*Delivered by [Grove](https://grove.cloud)*