### PR TITLE
feat: (W-054) feat: task outcome insights — cross-task pattern detection...

### DIFF
--- a/.grove/session-summary.md
+++ b/.grove/session-summary.md
@@ -1,75 +1,56 @@
-# Session Summary: W-042 (Session 4)
+# Session Summary: W-054
 
 ## Summary
 
-Ran a systematic gap analysis comparing all documentation against the actual source code using three parallel code-explorer agents (CLI commands, API endpoints, config options). Found and fixed 9 doc gaps and 3 inaccuracies. Added a comprehensive API Reference section to architecture.md covering all 27 REST endpoints and 6 WebSocket message types.
+Implemented cross-task pattern detection for Grove (issue #127). Added five new analytics queries, a REST endpoint, a CLI command, and an Insights dashboard tab that surfaces systemic failure patterns — most-failing gates with top error messages, retry rates by pipeline path, tree success rates, success rate trends over time, and common failure reasons.
 
 ## Changes Made
 
-### API Reference (architecture.md)
-- Full REST API reference table organized by domain: System, Trees, Tasks, Seeds, Orchestrator, Pipelines, Batch, Analytics, Events
-- WebSocket message reference: auth, chat, action (with step?), seed, seed_start, seed_stop
-- Authentication requirements noted for remote access
+### Backend — DB Queries (`src/broker/db.ts`)
+- `insightsFailingGates(since)` — gates ranked by failure count with most common error message per gate (correlated subquery)
+- `insightsRetriesByPath(since)` — retry counts grouped by pipeline path name
+- `insightsTreeFailureRates(since)` — success/failure breakdown per tree
+- `insightsSuccessTrend(since)` — daily success rate trend
+- `insightsCommonFailures(since, limit)` — top gate/message failure combos
+- All queries filter `status IN ('completed', 'failed')` for consistency
 
-### Configuration Gaps Fixed (configuration.md)
-- Added `workspace.name` section (required field, validated by config loader)
-- Added `merge` step type to the step types table
-- Added `label`, `on_success`, `max_retries` to the step fields table
-- Fixed tunnel `auth` field: documented `"none"` as valid value alongside `"token"`
-- Fixed tunnel `provider` field: noted `bore` and `ngrok` are defined but not yet implemented
+### Backend — API Endpoint (`src/broker/server.ts`)
+- `GET /api/analytics/insights?range=1h|4h|24h|7d` — returns all five insight datasets
+- Defaults to `7d` range (wider window suits pattern detection)
 
-### Custom Paths Fix (custom-paths.md)
-- Added `label` field to the step fields table (auto-generated from ID if omitted)
+### CLI Command (`src/cli/commands/insights.ts`)
+- `grove insights [range]` — formatted terminal output with color-coded bars
+- Range validation against valid values (1h, 4h, 24h, 7d)
+- Registered in CLI router and help output
 
-### CLI Reference Fix (cli-reference.md)
-- Clarified filter statuses (`draft`, `queued`, `active`, `completed`, `failed`) vs display statuses (`running`, `evaluating`, `paused`, `merged`)
-- Fixed `step_id` → `step` in resume endpoint description
+### Frontend — Data Layer (`web/src/hooks/useAnalytics.ts`)
+- Added `InsightsData` and sub-types (`FailingGate`, `RetriesByPath`, `TreeFailureRate`, `SuccessTrendDay`, `CommonFailure`)
+- Added `"insights"` to `DashboardTab` union
+- Added insights fetch branch and state in `useAnalytics` hook
 
-### Task Management Fix (task-management.md)
-- Fixed resume API body field: `step_id` → `step` (matching actual server.ts implementation)
-- Fixed WebSocket cancel example: added missing `"type": "action"` envelope field
+### Frontend — Dashboard (`web/src/components/Dashboard.tsx`)
+- "Insights" tab in TabStrip
+- `InsightsTab` component with:
+  - KPI summary (success rate, total failures, top failing gate, tasks retried)
+  - Most-failing gates panel with failure bars and top error messages
+  - Common failure reasons list
+  - Retries by path with retry percentage bars
+  - Tree success rates with color-coded bars (green/amber/red)
+  - Success rate trend chart (stacked completed/failed bars per day)
 
-### Quick Start (quick-start.md)
-- Updated architecture link description to mention API reference
-
-## Inaccuracies Found and Fixed
-
-1. **Resume API body field wrong** — docs used `step_id`, source code uses `step` (server.ts:612)
-2. **WebSocket cancel missing envelope** — docs omitted `"type": "action"`, but server.ts:170 requires it to route to the action handler
-3. **Tunnel auth "none" undocumented** — types.ts:190 declares `"token" | "none"` but docs only showed `"token"`
+### Tests (`tests/broker/db-insights.test.ts`)
+- 12 tests covering all 5 query methods
+- Tests use evaluator's actual array format for gate_results
+- Edge cases: empty data, passing-only gates, non-terminal task exclusion
 
 ## Files Modified
+- `src/broker/db.ts` — 5 new insight query methods
+- `src/broker/server.ts` — insights endpoint
+- `src/cli/commands/insights.ts` — new file, CLI command
+- `src/cli/index.ts` — command registration + help
+- `web/src/hooks/useAnalytics.ts` — types, state, fetch logic
+- `web/src/components/Dashboard.tsx` — InsightsTab + sub-components
+- `tests/broker/db-insights.test.ts` — new file, 12 tests
 
-- `docs/guides/architecture.md` — API reference section (96 new lines)
-- `docs/guides/configuration.md` — workspace section, step types/fields, tunnel config
-- `docs/guides/custom-paths.md` — label step field
-- `docs/guides/cli-reference.md` — display vs filter statuses, step field name fix
-- `docs/guides/task-management.md` — resume body field, WS cancel envelope
-- `docs/getting-started/quick-start.md` — architecture link description
-
-## Task Completion Status
-
-All items from the original issue (#82) have been documented across sessions 1–4:
-
-### User-facing — All done
-- Task dependencies, batch dispatch, GitHub issue sync, seeding
-- Filter persistence, status filter tabs, sidebar tree counts, cross-filtering
-- Activity indicators, dashboard, resume at step, cancel/pause
-
-### Developer-facing — All done
-- Step engine, evaluator, merge manager, worker lifecycle
-- Event bus, custom paths, worktree management
-- Orchestrator deep dive, batch analysis deep dive
-- **Full API reference** (new in session 4)
-
-### Configuration reference — All done
-- Quality gate config, budget settings, notification config
-- Workspace name, step label/on_success/max_retries, tunnel auth "none"
-
-### CLI reference — All done
-- All commands documented, batch command with options
-- Display vs filter statuses clarified
-
-### Remaining (blocked on unmerged features)
-- `default_path` per tree — blocked on #80 (not landed)
-- `grove batch --agent` flag — blocked on agent-powered analysis (not implemented)
+## Next Steps
+- None — feature is complete as specified in issue #127

--- a/src/broker/db.ts
+++ b/src/broker/db.ts
@@ -518,6 +518,125 @@ export class Database {
     );
   }
 
+  // ---- Cross-task insight analytics ----
+
+  /** Gates ranked by failure count, with the most common error message per gate */
+  insightsFailingGates(since: string): { gate: string; fail_count: number; top_message: string; top_message_count: number }[] {
+    return this.all(
+      `SELECT
+         json_extract(j.value, '$.gate') AS gate,
+         COUNT(*) AS fail_count,
+         (SELECT msg FROM (
+           SELECT json_extract(j2.value, '$.message') AS msg, COUNT(*) AS cnt
+           FROM tasks t2, json_each(t2.gate_results) AS j2
+           WHERE t2.gate_results IS NOT NULL
+             AND t2.status IN ('completed', 'failed')
+             AND t2.created_at >= ?
+             AND json_extract(j2.value, '$.passed') = 0
+             AND json_extract(j2.value, '$.gate') = json_extract(j.value, '$.gate')
+           GROUP BY msg
+           ORDER BY cnt DESC
+           LIMIT 1
+         )) AS top_message,
+         (SELECT cnt FROM (
+           SELECT json_extract(j2.value, '$.message') AS msg, COUNT(*) AS cnt
+           FROM tasks t2, json_each(t2.gate_results) AS j2
+           WHERE t2.gate_results IS NOT NULL
+             AND t2.status IN ('completed', 'failed')
+             AND t2.created_at >= ?
+             AND json_extract(j2.value, '$.passed') = 0
+             AND json_extract(j2.value, '$.gate') = json_extract(j.value, '$.gate')
+           GROUP BY msg
+           ORDER BY cnt DESC
+           LIMIT 1
+         )) AS top_message_count
+       FROM tasks, json_each(tasks.gate_results) AS j
+       WHERE tasks.gate_results IS NOT NULL
+         AND tasks.status IN ('completed', 'failed')
+         AND tasks.created_at >= ?
+         AND json_extract(j.value, '$.passed') = 0
+       GROUP BY gate
+       ORDER BY fail_count DESC
+       LIMIT 10`,
+      [since, since, since]
+    );
+  }
+
+  /** Average and max retry count grouped by pipeline path */
+  insightsRetriesByPath(since: string): { path_name: string; task_count: number; retried_count: number; avg_retries: number; max_retries: number }[] {
+    return this.all(
+      `SELECT
+         path_name,
+         COUNT(*) AS task_count,
+         SUM(CASE WHEN retry_count > 0 THEN 1 ELSE 0 END) AS retried_count,
+         COALESCE(AVG(CASE WHEN retry_count > 0 THEN retry_count END), 0) AS avg_retries,
+         COALESCE(MAX(retry_count), 0) AS max_retries
+       FROM tasks
+       WHERE created_at >= ?
+         AND status IN ('completed', 'failed')
+       GROUP BY path_name
+       ORDER BY avg_retries DESC`,
+      [since]
+    );
+  }
+
+  /** Success/failure breakdown per tree */
+  insightsTreeFailureRates(since: string): { tree_id: string; tree_name: string | null; completed: number; failed: number; total: number; success_rate: number }[] {
+    return this.all(
+      `SELECT
+         tk.tree_id,
+         t.name AS tree_name,
+         SUM(CASE WHEN tk.status = 'completed' THEN 1 ELSE 0 END) AS completed,
+         SUM(CASE WHEN tk.status = 'failed' THEN 1 ELSE 0 END) AS failed,
+         COUNT(*) AS total,
+         ROUND(CAST(SUM(CASE WHEN tk.status = 'completed' THEN 1 ELSE 0 END) AS REAL) / COUNT(*) * 100, 1) AS success_rate
+       FROM tasks tk
+       LEFT JOIN trees t ON tk.tree_id = t.id
+       WHERE tk.created_at >= ?
+         AND tk.status IN ('completed', 'failed')
+       GROUP BY tk.tree_id
+       ORDER BY success_rate ASC`,
+      [since]
+    );
+  }
+
+  /** Daily success rate trend */
+  insightsSuccessTrend(since: string): { date: string; completed: number; failed: number; total: number; success_rate: number }[] {
+    return this.all(
+      `SELECT
+         date(created_at) AS date,
+         SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed,
+         SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed,
+         COUNT(*) AS total,
+         ROUND(CAST(SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS REAL) / COUNT(*) * 100, 1) AS success_rate
+       FROM tasks
+       WHERE created_at >= ?
+         AND status IN ('completed', 'failed')
+       GROUP BY date
+       ORDER BY date ASC`,
+      [since]
+    );
+  }
+
+  /** Top N most common (gate, message) failure combinations */
+  insightsCommonFailures(since: string, limit = 10): { gate: string; message: string; count: number }[] {
+    return this.all(
+      `SELECT
+         json_extract(j.value, '$.gate') AS gate,
+         json_extract(j.value, '$.message') AS message,
+         COUNT(*) AS count
+       FROM tasks, json_each(tasks.gate_results) AS j
+       WHERE tasks.gate_results IS NOT NULL
+         AND tasks.status IN ('completed', 'failed')
+         AND tasks.created_at >= ?
+         AND json_extract(j.value, '$.passed') = 0
+       GROUP BY gate, message
+       ORDER BY count DESC
+       LIMIT ?`,
+      [since, limit]
+    );
+  }
+
   /** Convert "1h", "4h", "24h", "7d" to SQLite-compatible datetime string */
   private sinceToDate(since: string): string {
     const now = new Date();

--- a/src/broker/server.ts
+++ b/src/broker/server.ts
@@ -1040,6 +1040,19 @@ async function handleApi(
       return json(db.workerUtilization(range));
     }
 
+    // GET /api/analytics/insights?range=1h|4h|24h|7d — cross-task pattern insights
+    if (path === "/api/analytics/insights" && req.method === "GET") {
+      const url = new URL(req.url);
+      const since = rangeToSince(url.searchParams.get("range") ?? "7d");
+      return json({
+        failing_gates: db.insightsFailingGates(since),
+        retries_by_path: db.insightsRetriesByPath(since),
+        tree_failure_rates: db.insightsTreeFailureRates(since),
+        success_trend: db.insightsSuccessTrend(since),
+        common_failures: db.insightsCommonFailures(since),
+      });
+    }
+
     // GET /api/analytics/events — filtered event log
     if (path === "/api/analytics/events" && req.method === "GET") {
       const params = new URL(req.url).searchParams;

--- a/src/cli/commands/insights.ts
+++ b/src/cli/commands/insights.ts
@@ -1,0 +1,94 @@
+// grove insights — Cross-task pattern insights
+import pc from "picocolors";
+import { readBrokerInfo } from "../../broker/index";
+
+interface InsightsResponse {
+  failing_gates: { gate: string; fail_count: number; top_message: string; top_message_count: number }[];
+  retries_by_path: { path_name: string; task_count: number; retried_count: number; avg_retries: number; max_retries: number }[];
+  tree_failure_rates: { tree_id: string; tree_name: string | null; completed: number; failed: number; total: number; success_rate: number }[];
+  success_trend: { date: string; completed: number; failed: number; total: number; success_rate: number }[];
+  common_failures: { gate: string; message: string; count: number }[];
+}
+
+export async function run(args: string[]) {
+  const info = readBrokerInfo();
+  if (!info) {
+    console.log(`${pc.yellow("Grove is not running.")} Run ${pc.bold("grove up")} first.`);
+    return;
+  }
+
+  const validRanges = ["1h", "4h", "24h", "7d"];
+  const range = args[0] ?? "7d";
+  if (!validRanges.includes(range)) {
+    console.log(`${pc.red("Invalid range:")} ${range}. Use one of: ${validRanges.join(", ")}`);
+    return;
+  }
+
+  try {
+    const resp = await fetch(`${info.url}/api/analytics/insights?range=${range}`);
+    const data = (await resp.json()) as InsightsResponse;
+
+    console.log(`${pc.bold("Task Outcome Insights")} ${pc.dim(`(${range})`)}`);
+    console.log();
+
+    // --- Most-failing gates ---
+    if (data.failing_gates.length > 0) {
+      console.log(pc.bold("Most-Failing Gates"));
+      for (const g of data.failing_gates) {
+        const bar = pc.red("█".repeat(Math.min(g.fail_count, 20)));
+        console.log(`  ${bar} ${pc.white(g.gate)} ${pc.dim(`${g.fail_count} failures`)}`);
+        if (g.top_message) {
+          console.log(`     ${pc.dim("→")} ${pc.yellow(g.top_message)} ${pc.dim(`(×${g.top_message_count})`)}`);
+        }
+      }
+      console.log();
+    }
+
+    // --- Retries by path ---
+    if (data.retries_by_path.length > 0) {
+      console.log(pc.bold("Retries by Path"));
+      for (const p of data.retries_by_path) {
+        const retryPct = p.task_count > 0 ? Math.round((p.retried_count / p.task_count) * 100) : 0;
+        console.log(`  ${pc.green(p.path_name.padEnd(20))} ${pc.dim(`${p.task_count} tasks`)}  ${retryPct}% retried  avg ${p.avg_retries.toFixed(1)}  max ${p.max_retries}`);
+      }
+      console.log();
+    }
+
+    // --- Tree failure rates ---
+    if (data.tree_failure_rates.length > 0) {
+      console.log(pc.bold("Tree Success Rates"));
+      for (const t of data.tree_failure_rates) {
+        const name = (t.tree_name ?? t.tree_id).padEnd(20);
+        const color = t.success_rate >= 80 ? pc.green : t.success_rate >= 50 ? pc.yellow : pc.red;
+        console.log(`  ${name} ${color(`${t.success_rate}%`)} ${pc.dim(`(${t.completed}/${t.total})`)}`);
+      }
+      console.log();
+    }
+
+    // --- Success rate trend ---
+    if (data.success_trend.length > 0) {
+      console.log(pc.bold("Success Rate Trend"));
+      for (const d of data.success_trend) {
+        const bar = "█".repeat(Math.round(d.success_rate / 5));
+        const color = d.success_rate >= 80 ? pc.green : d.success_rate >= 50 ? pc.yellow : pc.red;
+        console.log(`  ${pc.dim(d.date)}  ${color(bar)} ${d.success_rate}%  ${pc.dim(`(${d.total} tasks)`)}`);
+      }
+      console.log();
+    }
+
+    // --- Common failures ---
+    if (data.common_failures.length > 0) {
+      console.log(pc.bold("Common Failure Reasons"));
+      for (const f of data.common_failures.slice(0, 5)) {
+        console.log(`  ${pc.red(`×${f.count}`)} ${pc.white(f.gate)}: ${pc.dim(f.message)}`);
+      }
+      console.log();
+    }
+
+    if (data.failing_gates.length === 0 && data.common_failures.length === 0) {
+      console.log(pc.green("  No failures detected in this time range. 🌳"));
+    }
+  } catch (err: any) {
+    console.log(`${pc.red("Error:")} ${err.message}`);
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,8 +16,9 @@ const commands: Record<string, () => Promise<{ run(args: string[]): Promise<void
   batch:  () => import("./commands/batch"),
   chat:   () => import("./commands/chat"),
   config:  () => import("./commands/config"),
-  cost:    () => import("./commands/cost"),
-  cleanup: () => import("./commands/cleanup"),
+  cost:     () => import("./commands/cost"),
+  insights: () => import("./commands/insights"),
+  cleanup:  () => import("./commands/cleanup"),
   plugins: () => import("./commands/plugins"),
   help:    () => import("./commands/help"),
   upgrade: () => import("./commands/upgrade"),
@@ -65,6 +66,7 @@ ${pc.bold("Commands:")}
   ${pc.green("chat")}      Send a message to the orchestrator
   ${pc.green("config")}    Manage config (version, validate, migrate)
   ${pc.green("cost")}      Spend breakdown
+  ${pc.green("insights")}  Cross-task pattern insights
   ${pc.green("plugins")}   Manage plugins
   ${pc.green("help")}      Show this help
   ${pc.green("upgrade")}   Upgrade to latest version

--- a/tests/broker/db-insights.test.ts
+++ b/tests/broker/db-insights.test.ts
@@ -1,0 +1,222 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "../../src/broker/db";
+import { SCHEMA_SQL } from "../../src/broker/schema-sql";
+import { join } from "node:path";
+import { unlinkSync, existsSync } from "node:fs";
+
+const TEST_DB = join(import.meta.dir, "test-insights.db");
+
+let db: Database;
+
+beforeEach(() => {
+  if (existsSync(TEST_DB)) unlinkSync(TEST_DB);
+  db = new Database(TEST_DB);
+  db.initFromString(SCHEMA_SQL);
+});
+
+afterEach(() => {
+  db.close();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    const f = TEST_DB + suffix;
+    if (existsSync(f)) unlinkSync(f);
+  }
+});
+
+function insertTree(id: string, name: string) {
+  db.treeUpsert({ id, name, path: `/code/${id}` });
+}
+
+function insertTask(
+  id: string,
+  treeId: string | null,
+  opts: {
+    status?: string; cost?: number; path_name?: string;
+    gate_results?: string; retry_count?: number; created_at?: string;
+  } = {}
+) {
+  db.run(
+    `INSERT INTO tasks (id, tree_id, title, status, cost_usd, path_name, gate_results, retry_count)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      id, treeId, `Task ${id}`, opts.status ?? "completed",
+      opts.cost ?? 0, opts.path_name ?? "development",
+      opts.gate_results ?? null, opts.retry_count ?? 0,
+    ]
+  );
+  if (opts.created_at !== undefined) {
+    db.run(`UPDATE tasks SET created_at = ? WHERE id = ?`, [opts.created_at, id]);
+  }
+}
+
+/** Build a gate_results JSON array in the evaluator's GateResult[] format */
+function gateResults(...gates: { gate: string; passed: boolean; message: string; tier?: string }[]): string {
+  return JSON.stringify(gates.map(g => ({
+    gate: g.gate,
+    passed: g.passed,
+    tier: g.tier ?? "hard",
+    message: g.message,
+  })));
+}
+
+const since = new Date(Date.now() - 7 * 86400000).toISOString();
+
+describe("insightsFailingGates", () => {
+  test("ranks gates by failure count with top message", () => {
+    insertTree("t", "T");
+    // CI fails 3 times with same message
+    insertTask("W-001", "t", { status: "failed", gate_results: gateResults({ gate: "ci", passed: false, message: "2 tests failed" }) });
+    insertTask("W-002", "t", { status: "failed", gate_results: gateResults({ gate: "ci", passed: false, message: "2 tests failed" }) });
+    insertTask("W-003", "t", { status: "failed", gate_results: gateResults({ gate: "ci", passed: false, message: "timeout" }) });
+    // Lint fails once
+    insertTask("W-004", "t", { status: "failed", gate_results: gateResults({ gate: "lint", passed: false, message: "unused import" }) });
+
+    const result = db.insightsFailingGates(since);
+    expect(result.length).toBe(2);
+    expect(result[0].gate).toBe("ci");
+    expect(result[0].fail_count).toBe(3);
+    expect(result[0].top_message).toBe("2 tests failed");
+    expect(result[0].top_message_count).toBe(2);
+    expect(result[1].gate).toBe("lint");
+    expect(result[1].fail_count).toBe(1);
+  });
+
+  test("ignores passing gates", () => {
+    insertTree("t", "T");
+    insertTask("W-001", "t", { gate_results: gateResults({ gate: "ci", passed: true, message: "ok" }) });
+
+    const result = db.insightsFailingGates(since);
+    expect(result).toEqual([]);
+  });
+
+  test("returns empty when no gate data", () => {
+    expect(db.insightsFailingGates(since)).toEqual([]);
+  });
+});
+
+describe("insightsRetriesByPath", () => {
+  test("groups retry stats by path", () => {
+    insertTree("t", "T");
+    insertTask("W-001", "t", { status: "completed", path_name: "development", retry_count: 2 });
+    insertTask("W-002", "t", { status: "completed", path_name: "development", retry_count: 0 });
+    insertTask("W-003", "t", { status: "failed", path_name: "adversarial", retry_count: 3 });
+
+    const result = db.insightsRetriesByPath(since);
+    expect(result.length).toBe(2);
+
+    // adversarial has higher avg retries, so it should be first (ORDER BY avg_retries DESC)
+    const adv = result.find(r => r.path_name === "adversarial")!;
+    expect(adv.task_count).toBe(1);
+    expect(adv.retried_count).toBe(1);
+    expect(adv.avg_retries).toBe(3);
+    expect(adv.max_retries).toBe(3);
+
+    const dev = result.find(r => r.path_name === "development")!;
+    expect(dev.task_count).toBe(2);
+    expect(dev.retried_count).toBe(1);
+    expect(dev.avg_retries).toBe(2);
+    expect(dev.max_retries).toBe(2);
+  });
+
+  test("excludes non-terminal tasks", () => {
+    insertTree("t", "T");
+    insertTask("W-001", "t", { status: "active", retry_count: 5 });
+
+    const result = db.insightsRetriesByPath(since);
+    expect(result).toEqual([]);
+  });
+});
+
+describe("insightsTreeFailureRates", () => {
+  test("computes success rate per tree", () => {
+    insertTree("titan", "Titan");
+    insertTree("grove", "Grove");
+    insertTask("W-001", "titan", { status: "completed" });
+    insertTask("W-002", "titan", { status: "completed" });
+    insertTask("W-003", "titan", { status: "failed" });
+    insertTask("W-004", "grove", { status: "failed" });
+
+    const result = db.insightsTreeFailureRates(since);
+    expect(result.length).toBe(2);
+
+    // Ordered by success_rate ASC, so grove (0%) comes first
+    expect(result[0].tree_name).toBe("Grove");
+    expect(result[0].success_rate).toBe(0);
+    expect(result[0].failed).toBe(1);
+
+    expect(result[1].tree_name).toBe("Titan");
+    expect(result[1].success_rate).toBeCloseTo(66.7, 0);
+    expect(result[1].completed).toBe(2);
+    expect(result[1].failed).toBe(1);
+  });
+
+  test("returns empty when no terminal tasks", () => {
+    insertTree("t", "T");
+    insertTask("W-001", "t", { status: "active" });
+    expect(db.insightsTreeFailureRates(since)).toEqual([]);
+  });
+});
+
+describe("insightsSuccessTrend", () => {
+  test("groups by date with success rate", () => {
+    insertTree("t", "T");
+    const today = new Date().toISOString().slice(0, 19).replace("T", " ");
+    const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 19).replace("T", " ");
+
+    insertTask("W-001", "t", { status: "completed", created_at: today });
+    insertTask("W-002", "t", { status: "failed", created_at: today });
+    insertTask("W-003", "t", { status: "completed", created_at: yesterday });
+
+    const result = db.insightsSuccessTrend(since);
+    expect(result.length).toBe(2);
+
+    // Ordered by date ASC
+    const yDay = result[0];
+    expect(yDay.completed).toBe(1);
+    expect(yDay.failed).toBe(0);
+    expect(yDay.success_rate).toBe(100);
+
+    const tDay = result[1];
+    expect(tDay.completed).toBe(1);
+    expect(tDay.failed).toBe(1);
+    expect(tDay.success_rate).toBe(50);
+  });
+
+  test("returns empty when no terminal tasks", () => {
+    expect(db.insightsSuccessTrend(since)).toEqual([]);
+  });
+});
+
+describe("insightsCommonFailures", () => {
+  test("returns top gate/message pairs by frequency", () => {
+    insertTree("t", "T");
+    // Same failure 3 times
+    for (let i = 1; i <= 3; i++) {
+      insertTask(`W-00${i}`, "t", { status: "failed", gate_results: gateResults({ gate: "ci", passed: false, message: "npm test failed" }) });
+    }
+    // Different failure once
+    insertTask("W-004", "t", { status: "failed", gate_results: gateResults({ gate: "lint", passed: false, message: "unused var" }) });
+
+    const result = db.insightsCommonFailures(since);
+    expect(result.length).toBe(2);
+    expect(result[0].gate).toBe("ci");
+    expect(result[0].message).toBe("npm test failed");
+    expect(result[0].count).toBe(3);
+    expect(result[1].gate).toBe("lint");
+    expect(result[1].count).toBe(1);
+  });
+
+  test("respects limit", () => {
+    insertTree("t", "T");
+    insertTask("W-001", "t", { status: "failed", gate_results: gateResults({ gate: "ci", passed: false, message: "a" }) });
+    insertTask("W-002", "t", { status: "failed", gate_results: gateResults({ gate: "lint", passed: false, message: "b" }) });
+
+    const result = db.insightsCommonFailures(since, 1);
+    expect(result.length).toBe(1);
+  });
+
+  test("returns empty when all gates pass", () => {
+    insertTree("t", "T");
+    insertTask("W-001", "t", { gate_results: gateResults({ gate: "ci", passed: true, message: "ok" }) });
+    expect(db.insightsCommonFailures(since)).toEqual([]);
+  });
+});

--- a/web/src/components/Dashboard.tsx
+++ b/web/src/components/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useAnalytics, type TimeRange, type DashboardTab, type CostData, type GateData, type TimelineData, type TimelineTask, type GateAnalytics, type UtilizationBucket } from "../hooks/useAnalytics";
+import { useAnalytics, type TimeRange, type DashboardTab, type CostData, type GateData, type TimelineData, type TimelineTask, type GateAnalytics, type UtilizationBucket, type InsightsData } from "../hooks/useAnalytics";
 import type { WsMessage } from "../hooks/useWebSocket";
 import type { Status } from "../hooks/useTasks";
 import ActivityTimeline from "./ActivityTimeline";
@@ -14,7 +14,7 @@ interface Props {
 export default function Dashboard({ wsMessages, status }: Props) {
   const [activeTab, setActiveTab] = useState<DashboardTab>("overview");
   const [range, setRange] = useState<TimeRange>("24h");
-  const { costData, gateData, timelineData, utilizationData, loading, refresh } = useAnalytics(range, activeTab, wsMessages);
+  const { costData, gateData, timelineData, utilizationData, insightsData, loading, refresh } = useAnalytics(range, activeTab, wsMessages);
 
   const isLive = range === "1h" || range === "4h";
 
@@ -62,6 +62,9 @@ export default function Dashboard({ wsMessages, status }: Props) {
           {activeTab === "events" && (
             <EventsTab />
           )}
+          {activeTab === "insights" && (
+            <InsightsTab data={insightsData} />
+          )}
         </>
       )}
     </div>
@@ -77,6 +80,7 @@ function TabStrip({ active, onChange }: { active: DashboardTab; onChange: (t: Da
     { id: "gates", label: "Gates" },
     { id: "activity", label: "Activity" },
     { id: "events", label: "Events" },
+    { id: "insights", label: "Insights" },
   ];
   return (
     <div className="flex gap-0.5 bg-zinc-800 rounded-md p-0.5">
@@ -459,6 +463,186 @@ function EventsTab() {
     <Panel title="Event Log">
       <EventLogViewer />
     </Panel>
+  );
+}
+
+// ---- Insights Tab ----
+
+function InsightsTab({ data }: { data: InsightsData | null }) {
+  if (!data) {
+    return <div className="text-zinc-600 text-xs py-4 text-center">Loading insights...</div>;
+  }
+
+  const hasData = data.failing_gates.length > 0 || data.common_failures.length > 0 || data.success_trend.length > 0 || data.retries_by_path.length > 0 || data.tree_failure_rates.length > 0;
+
+  if (!hasData) {
+    return (
+      <Panel title="Task Outcome Insights">
+        <div className="text-zinc-600 text-xs py-4 text-center">No completed or failed tasks in this time range</div>
+      </Panel>
+    );
+  }
+
+  return (
+    <>
+      {/* KPI summary */}
+      <InsightKpis data={data} />
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mt-3">
+        {/* Most-failing gates */}
+        <Panel title="Most-Failing Gates">
+          {data.failing_gates.length === 0 ? (
+            <div className="text-zinc-600 text-xs py-2 text-center">No gate failures</div>
+          ) : (
+            <div className="space-y-2">
+              {data.failing_gates.map((g) => {
+                const maxFail = data.failing_gates[0]?.fail_count ?? 1;
+                return (
+                  <div key={g.gate}>
+                    <div className="flex justify-between text-[10px] mb-0.5">
+                      <span className="text-zinc-400">{g.gate}</span>
+                      <span className="text-red-400">{g.fail_count} failures</span>
+                    </div>
+                    <div className="bg-zinc-800 h-2 rounded-full overflow-hidden">
+                      <div className="bg-red-500 h-full rounded-full transition-all" style={{ width: `${(g.fail_count / maxFail) * 100}%` }} />
+                    </div>
+                    {g.top_message && (
+                      <div className="text-[9px] text-zinc-600 mt-0.5 truncate" title={g.top_message}>
+                        → {g.top_message} <span className="text-zinc-700">(×{g.top_message_count})</span>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </Panel>
+
+        {/* Common failure reasons */}
+        <Panel title="Common Failure Reasons">
+          {data.common_failures.length === 0 ? (
+            <div className="text-zinc-600 text-xs py-2 text-center">No failures recorded</div>
+          ) : (
+            <div className="space-y-1.5">
+              {data.common_failures.slice(0, 8).map((f, i) => (
+                <div key={i} className="flex items-start gap-2 text-[10px]">
+                  <span className="text-red-400 flex-shrink-0 font-mono">×{f.count}</span>
+                  <span className="text-zinc-500 flex-shrink-0">{f.gate}</span>
+                  <span className="text-zinc-400 truncate" title={f.message}>{f.message}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </Panel>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mt-3">
+        {/* Retries by path */}
+        <Panel title="Retries by Path">
+          {data.retries_by_path.length === 0 ? (
+            <div className="text-zinc-600 text-xs py-2 text-center">No data</div>
+          ) : (
+            <div className="space-y-2">
+              {data.retries_by_path.map((p) => {
+                const retryPct = p.task_count > 0 ? Math.round((p.retried_count / p.task_count) * 100) : 0;
+                return (
+                  <div key={p.path_name}>
+                    <div className="flex justify-between text-[10px] mb-0.5">
+                      <span className="text-zinc-400">{p.path_name}</span>
+                      <span className="text-zinc-500">{retryPct}% retried · avg {p.avg_retries.toFixed(1)} per retry</span>
+                    </div>
+                    <div className="bg-zinc-800 h-2 rounded-full overflow-hidden">
+                      <div className="bg-amber-500 h-full rounded-full transition-all" style={{ width: `${retryPct}%` }} />
+                    </div>
+                    <div className="text-[9px] text-zinc-600 mt-0.5">
+                      {p.task_count} tasks · {p.retried_count} retried · max {p.max_retries}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </Panel>
+
+        {/* Tree success rates */}
+        <Panel title="Tree Success Rates">
+          {data.tree_failure_rates.length === 0 ? (
+            <div className="text-zinc-600 text-xs py-2 text-center">No data</div>
+          ) : (
+            <div className="space-y-2">
+              {data.tree_failure_rates.map((t) => {
+                const color = t.success_rate >= 80 ? "bg-emerald-500" : t.success_rate >= 50 ? "bg-amber-500" : "bg-red-500";
+                return (
+                  <div key={t.tree_id}>
+                    <div className="flex justify-between text-[10px] mb-0.5">
+                      <span className="text-zinc-400">{t.tree_name ?? t.tree_id}</span>
+                      <span className={t.success_rate >= 80 ? "text-emerald-400" : t.success_rate >= 50 ? "text-amber-400" : "text-red-400"}>
+                        {t.success_rate}%
+                      </span>
+                    </div>
+                    <div className="bg-zinc-800 h-2 rounded-full overflow-hidden">
+                      <div className={`${color} h-full rounded-full transition-all`} style={{ width: `${t.success_rate}%` }} />
+                    </div>
+                    <div className="text-[9px] text-zinc-600 mt-0.5">
+                      {t.completed} completed · {t.failed} failed
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </Panel>
+      </div>
+
+      {/* Success rate trend */}
+      {data.success_trend.length > 1 && (
+        <div className="mt-3">
+          <Panel title="Success Rate Trend">
+            <SuccessRateChart data={data.success_trend} />
+          </Panel>
+        </div>
+      )}
+    </>
+  );
+}
+
+function InsightKpis({ data }: { data: InsightsData }) {
+  const totalTasks = data.success_trend.reduce((s, d) => s + d.total, 0);
+  const totalFailed = data.success_trend.reduce((s, d) => s + d.failed, 0);
+  const overallRate = totalTasks > 0 ? Math.round(((totalTasks - totalFailed) / totalTasks) * 100) : 0;
+  const topGate = data.failing_gates[0];
+  const totalRetried = data.retries_by_path.reduce((s, p) => s + p.retried_count, 0);
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-1">
+      <KpiCard label="Success Rate" value={totalTasks > 0 ? `${overallRate}%` : "—"} sub={`${totalTasks - totalFailed}/${totalTasks} tasks`} />
+      <KpiCard label="Total Failures" value={String(totalFailed)} sub={totalFailed > 0 ? `across ${data.tree_failure_rates.filter(t => t.failed > 0).length} trees` : "none"} />
+      <KpiCard label="Top Failing Gate" value={topGate?.gate ?? "—"} sub={topGate ? `${topGate.fail_count} failures` : "no failures"} />
+      <KpiCard label="Tasks Retried" value={String(totalRetried)} sub={`${data.retries_by_path.length} paths`} />
+    </div>
+  );
+}
+
+function SuccessRateChart({ data }: { data: InsightsData["success_trend"] }) {
+  const maxTotal = Math.max(...data.map(d => d.total));
+
+  return (
+    <div className="space-y-1">
+      {data.map((d) => (
+        <div key={d.date} className="flex items-center gap-2">
+          <div className="text-[9px] text-zinc-600 w-16 flex-shrink-0">{d.date.slice(5)}</div>
+          <div className="flex-1 flex h-3 rounded-full overflow-hidden bg-zinc-800">
+            {d.completed > 0 && (
+              <div className="bg-emerald-500 transition-all" style={{ width: `${(d.completed / maxTotal) * 100}%` }} title={`${d.completed} completed`} />
+            )}
+            {d.failed > 0 && (
+              <div className="bg-red-500 transition-all" style={{ width: `${(d.failed / maxTotal) * 100}%` }} title={`${d.failed} failed`} />
+            )}
+          </div>
+          <div className="text-[9px] text-zinc-500 w-10 text-right">{d.success_rate}%</div>
+        </div>
+      ))}
+    </div>
   );
 }
 

--- a/web/src/hooks/useAnalytics.ts
+++ b/web/src/hooks/useAnalytics.ts
@@ -5,7 +5,7 @@ import { api } from "../api/client";
 // ---- Types ----
 
 export type TimeRange = "1h" | "4h" | "24h" | "7d";
-export type DashboardTab = "overview" | "costs" | "gates" | "activity" | "events";
+export type DashboardTab = "overview" | "costs" | "gates" | "activity" | "events" | "insights";
 
 export interface CostByTree {
   tree_name: string;
@@ -71,6 +71,52 @@ export interface UtilizationBucket {
   active_workers: number;
 }
 
+export interface FailingGate {
+  gate: string;
+  fail_count: number;
+  top_message: string;
+  top_message_count: number;
+}
+
+export interface RetriesByPath {
+  path_name: string;
+  task_count: number;
+  retried_count: number;
+  avg_retries: number;
+  max_retries: number;
+}
+
+export interface TreeFailureRate {
+  tree_id: string;
+  tree_name: string | null;
+  completed: number;
+  failed: number;
+  total: number;
+  success_rate: number;
+}
+
+export interface SuccessTrendDay {
+  date: string;
+  completed: number;
+  failed: number;
+  total: number;
+  success_rate: number;
+}
+
+export interface CommonFailure {
+  gate: string;
+  message: string;
+  count: number;
+}
+
+export interface InsightsData {
+  failing_gates: FailingGate[];
+  retries_by_path: RetriesByPath[];
+  tree_failure_rates: TreeFailureRate[];
+  success_trend: SuccessTrendDay[];
+  common_failures: CommonFailure[];
+}
+
 // WS event types that trigger a refresh in live mode
 const LIVE_EVENTS = new Set(["task:status", "cost:updated", "gate:result", "task:created", "worker:ended"]);
 
@@ -89,6 +135,7 @@ export function useAnalytics(
   const [gateData, setGateData] = useState<GateData | null>(null);
   const [timelineData, setTimelineData] = useState<TimelineData | null>(null);
   const [utilizationData, setUtilizationData] = useState<UtilizationBucket[] | null>(null);
+  const [insightsData, setInsightsData] = useState<InsightsData | null>(null);
   const [loading, setLoading] = useState(false);
   const lastWsMsgTs = useRef(0);
 
@@ -110,6 +157,10 @@ export function useAnalytics(
       if (tab === "activity") {
         const data = await api<UtilizationBucket[]>(`/api/analytics/utilization?range=${r}`);
         setUtilizationData(data);
+      }
+      if (tab === "insights") {
+        const data = await api<InsightsData>(`/api/analytics/insights?range=${r}`);
+        setInsightsData(data);
       }
     } catch {
       // API not available
@@ -137,5 +188,5 @@ export function useAnalytics(
     fetchTab(activeTab, range);
   }, [activeTab, range, fetchTab]);
 
-  return { costData, gateData, timelineData, utilizationData, loading, refresh };
+  return { costData, gateData, timelineData, utilizationData, insightsData, loading, refresh };
 }


### PR DESCRIPTION
## feat: task outcome insights — cross-task pattern detection Issue #127

## Problem

When tasks fail and retry, workers get gate failure details for that specific task. But there's no cross-task learning. If 5 tasks in a row fail the same lint gate because workers don't run the linter before committing, nothing surfaces that pattern.

## Proposed Solution

A `grove insights` CLI command and `/api/analytics/insights` endpoint that analyzes completed/failed tasks:

- Gate that fails most often (with most common error message)
- Average retries per path (which pipeline is most efficient?)
- Trees where workers consistently need more attempts
- Common CI failure reasons
- Success rate trends over time

Surface in Dashboard as an "Insights" tab. Optionally allow acting on insights: "Add linter instruction to worker overlay for tree X."

## Why This Matters

Repeated failures on the same gate indicate a systemic prompt issue, not a per-task problem. Grove should detect patterns and surface them to the user rather than burning tokens on the same mistake.

## Context

- Events table in SQLite stores all gate results, worker outcomes
- Analytics queries in `src/broker/db.ts`
- Dashboard in `web/src/components/Dashboard.tsx`

**Task:** W-054
**Path:** development
**Cost:** $0.00
**Files changed:** 16

### Quality Gates
- commits: passed — 1 commit on branch
- tests: passed — No test command configured — skipped
- diff_size: passed — 812 lines changed

Closes #127

---
*Delivered by [Grove](https://grove.cloud)*