### PR TITLE
feat: (W-057) feat: show task counts on status filter tabs + failed badge...

### DIFF
--- a/web/src/components/TaskList.tsx
+++ b/web/src/components/TaskList.tsx
@@ -53,6 +53,17 @@ export default function TaskList({ tasks, trees, paths, getActivity, getActivity
     return (allTasks ?? tasks).filter(t => t.tree_id === selectedTree && t.status === "draft").length;
   }, [selectedTree, allTasks, tasks]);
 
+  // Compute per-status counts for filter tabs (scoped to selectedTree if set)
+  const filterCounts = useMemo(() => {
+    const src = (allTasks ?? tasks).filter(t => !selectedTree || t.tree_id === selectedTree);
+    return {
+      all: src.length,
+      active: src.filter(t => ["draft", "queued", "active"].includes(t.status)).length,
+      failed: src.filter(t => t.status === "failed").length,
+      done: src.filter(t => t.status === "completed").length,
+    };
+  }, [allTasks, tasks, selectedTree]);
+
   useEffect(() => {
     if (wsMessage) seedState.handleWsMessage(wsMessage);
   }, [wsMessage, seedState.handleWsMessage]);
@@ -136,19 +147,27 @@ export default function TaskList({ tasks, trees, paths, getActivity, getActivity
           >
             + New
           </button>
-          {(["all", "active", "failed", "done"] as const).map((f) => (
-            <button
-              key={f}
-              onClick={() => onFilterChange(f)}
-              className={`px-3 py-1 rounded-full capitalize ${
-                filter === f
-                  ? "bg-emerald-400/15 text-emerald-400"
-                  : "text-zinc-500 hover:text-zinc-300"
-              }`}
-            >
-              {f}
-            </button>
-          ))}
+          {(["all", "active", "failed", "done"] as const).map((f) => {
+            const count = filterCounts[f];
+            const isFailedAlert = f === "failed" && filterCounts.failed > 0 && filter !== "failed";
+            return (
+              <button
+                key={f}
+                onClick={() => onFilterChange(f)}
+                className={`px-3 py-1 rounded-full capitalize ${
+                  filter === f
+                    ? "bg-emerald-400/15 text-emerald-400"
+                    : isFailedAlert
+                      ? "text-red-400 bg-red-400/15"
+                      : "text-zinc-500 hover:text-zinc-300"
+                }`}
+              >
+                {f}
+                <span className="ml-1 text-[10px] opacity-70">({count})</span>
+                {isFailedAlert && <span className="ml-1 text-red-400 animate-pulse">●</span>}
+              </button>
+            );
+          })}
         </div>
       </div>
 


### PR DESCRIPTION
## feat: show task counts on status filter tabs + failed badge Issue #133

## Problem

The status filter tabs (All, Active, Failed, Done) show plain text labels with no counts. When a task fails, there's no visual indicator unless the user happens to be on the right filter. Failed tasks can go unnoticed.

## Proposed Solution

Add counts to each filter tab and a visual alert for failed tasks.

### Tab counts
```
All (12)   Active (3)   Failed (2)   Done (7)
```

### Failed alert
When failed count > 0, make the Failed tab visually distinct even when not selected:
- Red dot/badge on the "Failed" tab (e.g., `Failed ●2`)
- Pulsing or highlighted to draw attention

### Implementation

- [ ] **`web/src/components/TaskList.tsx`** — Compute counts from `allTasks` (same pattern as existing `draftCount` at line 51-54). For each status filter, count matching tasks (respecting `selectedTree` filter). Render count in tab label: `{f} ({count})`.
- [ ] **Failed badge** — When `failedCount > 0` and filter !== "failed", add a red badge/dot to the Failed tab. Something like: `text-red-400 bg-red-400/15` styling + count.
- [ ] Counts should use `allTasks` (unfiltered by status) to avoid circular dependency — tabs show counts for all statuses, current filter highlights the active one.

### Status mapping for counts
- **all** — total count of non-closed tasks
- **active** — status `active` + `queued`
- **failed** — status `failed`
- **done** — status `completed` + `merged`

## Context

- Filter tabs: `web/src/components/TaskList.tsx` lines 139-151
- `allTasks` prop already available (used for `draftCount` on line 51-54)
- `StatusFilter` type: `web/src/App.tsx`
- Filtering logic already in `App.tsx` — TaskList receives pre-filtered `tasks` + unfiltered `allTasks`

**Task:** W-057
**Path:** development
**Cost:** $0.00
**Files changed:** 17

### Quality Gates
- commits: passed — 1 commit on branch
- tests: passed — No test command configured — skipped
- diff_size: passed — 45 lines changed

Closes #133

---
*Delivered by [Grove](https://grove.cloud)*