### PR TITLE
feat: (W-056) add close/delete task actions to GUI

### DIFF
--- a/.grove/session-summary.md
+++ b/.grove/session-summary.md
@@ -1,56 +1,51 @@
-# Session Summary: W-054
+# Session Summary: W-056
 
 ## Summary
 
-Implemented cross-task pattern detection for Grove (issue #127). Added five new analytics queries, a REST endpoint, a CLI command, and an Insights dashboard tab that surfaces systemic failure patterns — most-failing gates with top error messages, retry rates by pipeline path, tree success rates, success rate trends over time, and common failure reasons.
+Implemented close/archive tasks from the GUI (issue #132). Added a new `closed` terminal status, Close and Delete actions in TaskDetail, and a "closed" filter tab in the task list. Closed tasks are hidden from the default view.
 
 ## Changes Made
 
-### Backend — DB Queries (`src/broker/db.ts`)
-- `insightsFailingGates(since)` — gates ranked by failure count with most common error message per gate (correlated subquery)
-- `insightsRetriesByPath(since)` — retry counts grouped by pipeline path name
-- `insightsTreeFailureRates(since)` — success/failure breakdown per tree
-- `insightsSuccessTrend(since)` — daily success rate trend
-- `insightsCommonFailures(since, limit)` — top gate/message failure combos
-- All queries filter `status IN ('completed', 'failed')` for consistency
+### Shared Types (`src/shared/types.ts`)
+- Added `Closed = "closed"` to `TaskStatus` enum
 
-### Backend — API Endpoint (`src/broker/server.ts`)
-- `GET /api/analytics/insights?range=1h|4h|24h|7d` — returns all five insight datasets
-- Defaults to `7d` range (wider window suits pattern detection)
+### Database (`src/broker/db.ts`)
+- Added `taskDelete(taskId)` method for hard-deleting tasks
+- Updated `getNewlyUnblocked` to exclude `closed` tasks from dependency resolution
 
-### CLI Command (`src/cli/commands/insights.ts`)
-- `grove insights [range]` — formatted terminal output with color-coded bars
-- Range validation against valid values (1h, 4h, 24h, 7d)
-- Registered in CLI router and help output
+### Server (`src/broker/server.ts`)
+- Added `close_task` WebSocket action handler — sets draft/failed tasks to `closed` status
+- Added `DELETE /api/tasks/:id` REST endpoint — hard-deletes draft tasks only
 
-### Frontend — Data Layer (`web/src/hooks/useAnalytics.ts`)
-- Added `InsightsData` and sub-types (`FailingGate`, `RetriesByPath`, `TreeFailureRate`, `SuccessTrendDay`, `CommonFailure`)
-- Added `"insights"` to `DashboardTab` union
-- Added insights fetch branch and state in `useAnalytics` hook
+### Orchestrator (`src/agents/orchestrator.ts`)
+- Excluded `closed` tasks from the orchestrator's active-tasks prompt query
 
-### Frontend — Dashboard (`web/src/components/Dashboard.tsx`)
-- "Insights" tab in TabStrip
-- `InsightsTab` component with:
-  - KPI summary (success rate, total failures, top failing gate, tasks retried)
-  - Most-failing gates panel with failure bars and top error messages
-  - Common failure reasons list
-  - Retries by path with retry percentage bars
-  - Tree success rates with color-coded bars (green/amber/red)
-  - Success rate trend chart (stacked completed/failed bars per day)
+### Frontend — TaskDetail (`web/src/components/TaskDetail.tsx`)
+- Added "Close" button (muted variant) for draft and failed tasks
+- Added "Delete" button (danger variant) for draft tasks with confirmation dialog
+- Extended `ActionButton` to support `muted` variant styling
+- Excluded `closed` tasks from showing the Cancel button
 
-### Tests (`tests/broker/db-insights.test.ts`)
-- 12 tests covering all 5 query methods
-- Tests use evaluator's actual array format for gate_results
-- Edge cases: empty data, passing-only gates, non-terminal task exclusion
+### Frontend — App (`web/src/App.tsx`)
+- Added `"closed"` to `StatusFilter` union type
+- Updated `applyStatusFilter`: "all" now hides closed tasks; "closed" filter shows only closed
+
+### Frontend — TaskList (`web/src/components/TaskList.tsx`)
+- Added `closed` status color (muted zinc)
+- Added "closed" to filter button bar
+
+### Tests (`tests/broker/db-close-delete.test.ts`)
+- 7 tests covering close (draft, failed, terminal state exclusion, event creation) and delete (success, not-found, isolation)
 
 ## Files Modified
-- `src/broker/db.ts` — 5 new insight query methods
-- `src/broker/server.ts` — insights endpoint
-- `src/cli/commands/insights.ts` — new file, CLI command
-- `src/cli/index.ts` — command registration + help
-- `web/src/hooks/useAnalytics.ts` — types, state, fetch logic
-- `web/src/components/Dashboard.tsx` — InsightsTab + sub-components
-- `tests/broker/db-insights.test.ts` — new file, 12 tests
+- `src/shared/types.ts` — added Closed enum value
+- `src/broker/db.ts` — taskDelete method, getNewlyUnblocked exclusion
+- `src/broker/server.ts` — close_task WS handler, DELETE endpoint
+- `src/agents/orchestrator.ts` — excluded closed from active tasks
+- `web/src/App.tsx` — StatusFilter type, filter logic
+- `web/src/components/TaskDetail.tsx` — Close/Delete buttons, muted variant
+- `web/src/components/TaskList.tsx` — closed color, filter tab
+- `tests/broker/db-close-delete.test.ts` — new test file
 
 ## Next Steps
-- None — feature is complete as specified in issue #127
+- None — feature is complete as specified in issue #132

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -98,7 +98,7 @@ export function buildOrchestratorPrompt(db: Database): string {
   const treeList = trees.map(t => `- ${t.id}: ${t.path}${t.github ? ` (${t.github})` : ""}`).join("\n");
 
   const activeTasks = db.all<{ id: string; title: string; status: string; tree_id: string }>(
-    "SELECT id, title, status, tree_id FROM tasks WHERE status NOT IN ('completed', 'merged', 'failed') ORDER BY created_at DESC LIMIT 20"
+    "SELECT id, title, status, tree_id FROM tasks WHERE status NOT IN ('completed', 'merged', 'failed', 'closed') ORDER BY created_at DESC LIMIT 20"
   );
   const taskList = activeTasks.length > 0
     ? activeTasks.map(t => `- ${t.id}: [${t.status}] ${t.title} (${t.tree_id || "no tree"})`).join("\n")

--- a/src/broker/db.ts
+++ b/src/broker/db.ts
@@ -133,6 +133,10 @@ export class Database {
     return this.db.prepare("DELETE FROM tasks WHERE tree_id = ?").run(treeId).changes;
   }
 
+  taskDelete(taskId: string): boolean {
+    return this.db.prepare("DELETE FROM tasks WHERE id = ?").run(taskId).changes > 0;
+  }
+
   // ---- Task helpers ----
 
   taskGet(taskId: string): Task | null {
@@ -190,7 +194,7 @@ export class Database {
     const candidates = this.all<Task>(
       `SELECT * FROM tasks
        WHERE (',' || depends_on || ',') LIKE ?
-         AND status NOT IN ('completed', 'failed')`,
+         AND status NOT IN ('completed', 'failed', 'closed')`,
       [`%,${completedTaskId},%`]
     );
     return candidates.filter(t => !this.isTaskBlocked(t.id));

--- a/src/broker/server.ts
+++ b/src/broker/server.ts
@@ -350,6 +350,13 @@ function handleWsAction(data: any, db: Database) {
       stopWorker(data.taskId, db);
       break;
     }
+    case "close_task": {
+      const task = db.taskGet(data.taskId);
+      if (!task) break;
+      if (task.status !== "draft" && task.status !== "failed") break;
+      db.taskSetStatus(data.taskId, "closed");
+      break;
+    }
     case "resume_task": {
       const task = db.taskGet(data.taskId);
       if (!task || task.status === "completed") break;
@@ -741,6 +748,18 @@ async function handleApi(
         message: { id: 0, source: "user", channel: "main", content: body.text, created_at: new Date().toISOString() },
       });
       onChat?.(body.text);
+      return json({ ok: true });
+    }
+
+    // DELETE /api/tasks/:id — hard-delete a draft task
+    const deleteMatch = path.match(/^\/api\/tasks\/([A-Z]+-\d+)$/);
+    if (deleteMatch && req.method === "DELETE") {
+      const taskId = deleteMatch[1];
+      const task = db.taskGet(taskId);
+      if (!task) return json({ error: "Task not found" }, 404);
+      if (task.status !== "draft") return json({ error: "Only draft tasks can be deleted" }, 400);
+      db.taskDelete(taskId);
+      db.addEvent(null, null, "task_deleted", `Deleted draft task ${taskId}`);
       return json({ ok: true });
     }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -10,6 +10,7 @@ export enum TaskStatus {
   Active = "active",
   Completed = "completed",
   Failed = "failed",
+  Closed = "closed",
 }
 
 export enum AgentRole {

--- a/tests/broker/db-close-delete.test.ts
+++ b/tests/broker/db-close-delete.test.ts
@@ -1,0 +1,76 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "../../src/broker/db";
+import { SCHEMA_SQL } from "../../src/broker/schema-sql";
+import { join } from "node:path";
+import { unlinkSync, existsSync } from "node:fs";
+
+const TEST_DB = join(import.meta.dir, "test-close-delete.db");
+
+let db: Database;
+
+beforeEach(() => {
+  if (existsSync(TEST_DB)) unlinkSync(TEST_DB);
+  db = new Database(TEST_DB);
+  db.initFromString(SCHEMA_SQL);
+});
+
+afterEach(() => {
+  db.close();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    const f = TEST_DB + suffix;
+    if (existsSync(f)) unlinkSync(f);
+  }
+});
+
+describe("Close task (soft close via status)", () => {
+  test("close a draft task", () => {
+    db.run("INSERT INTO tasks (id, title, status) VALUES (?, ?, ?)", ["W-001", "Draft task", "draft"]);
+    db.taskSetStatus("W-001", "closed");
+    const task = db.taskGet("W-001");
+    expect(task!.status).toBe("closed");
+  });
+
+  test("close a failed task", () => {
+    db.run("INSERT INTO tasks (id, title, status) VALUES (?, ?, ?)", ["W-001", "Failed task", "failed"]);
+    db.taskSetStatus("W-001", "closed");
+    const task = db.taskGet("W-001");
+    expect(task!.status).toBe("closed");
+  });
+
+  test("closed tasks are excluded from getNewlyUnblocked", () => {
+    db.run("INSERT INTO tasks (id, title, status) VALUES (?, ?, ?)", ["W-001", "Blocker", "completed"]);
+    db.run("INSERT INTO tasks (id, title, status, depends_on) VALUES (?, ?, ?, ?)", ["W-002", "Blocked", "closed", "W-001"]);
+    const unblocked = db.getNewlyUnblocked("W-001");
+    expect(unblocked.length).toBe(0);
+  });
+
+  test("closed task creates status_change event", () => {
+    db.run("INSERT INTO tasks (id, title, status) VALUES (?, ?, ?)", ["W-001", "Task", "draft"]);
+    db.taskSetStatus("W-001", "closed");
+    const events = db.eventsByTask("W-001");
+    expect(events.length).toBe(1);
+    expect(events[0].summary).toContain("closed");
+  });
+});
+
+describe("Delete task (hard delete)", () => {
+  test("delete an existing task", () => {
+    db.run("INSERT INTO tasks (id, title, status) VALUES (?, ?, ?)", ["W-001", "Draft", "draft"]);
+    const deleted = db.taskDelete("W-001");
+    expect(deleted).toBe(true);
+    expect(db.taskGet("W-001")).toBeNull();
+  });
+
+  test("delete nonexistent task returns false", () => {
+    const deleted = db.taskDelete("W-999");
+    expect(deleted).toBe(false);
+  });
+
+  test("delete does not affect other tasks", () => {
+    db.run("INSERT INTO tasks (id, title, status) VALUES (?, ?, ?)", ["W-001", "Delete me", "draft"]);
+    db.run("INSERT INTO tasks (id, title, status) VALUES (?, ?, ?)", ["W-002", "Keep me", "draft"]);
+    db.taskDelete("W-001");
+    expect(db.taskGet("W-001")).toBeNull();
+    expect(db.taskGet("W-002")).not.toBeNull();
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import Dashboard from "./components/Dashboard";
 
 const DagEditor = lazy(() => import("./components/DagEditor"));
 
-export type StatusFilter = "all" | "active" | "failed" | "done";
+export type StatusFilter = "all" | "active" | "failed" | "done" | "closed";
 
 type View = "tasks" | "settings" | "dashboard" | "dag";
 type MobileTab = "trees" | "tasks" | "chat";
@@ -92,7 +92,9 @@ export default function App() {
     if (filter === "active") return tasks.filter(t => ["draft", "queued", "active"].includes(t.status));
     if (filter === "failed") return tasks.filter(t => t.status === "failed");
     if (filter === "done") return tasks.filter(t => t.status === "completed");
-    return tasks;
+    if (filter === "closed") return tasks.filter(t => t.status === "closed");
+    // "all" shows everything except closed (like completed, they're dismissed)
+    return tasks.filter(t => t.status !== "closed");
   }, []);
 
   /** Tasks filtered by status (for counts), then further by selected tree (for display) */

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { api } from "../api/client";
 import type { Task, Tree } from "../hooks/useTasks";
 import Pipeline from "./Pipeline";
 import TaskForm from "./TaskForm";
@@ -221,8 +222,17 @@ export default function TaskDetail({ task, activityLog, steps, send, trees, path
         {task.status === "active" && !task.paused && (
           <ActionButton label="Pause" onClick={() => send({ type: "action", action: "pause_task", taskId: task.id })} />
         )}
-        {task.status !== "completed" && task.status !== "failed" && (
+        {task.status !== "completed" && task.status !== "failed" && task.status !== "closed" && (
           <ActionButton label="Cancel" variant="danger" onClick={() => send({ type: "action", action: "cancel_task", taskId: task.id })} />
+        )}
+        {(task.status === "draft" || task.status === "failed") && (
+          <ActionButton label="Close" variant="muted" onClick={() => send({ type: "action", action: "close_task", taskId: task.id })} />
+        )}
+        {task.status === "draft" && (
+          <ActionButton label="Delete" variant="danger" onClick={async () => {
+            if (!confirm("Permanently delete this draft task?")) return;
+            try { await api(`/api/tasks/${task.id}`, { method: "DELETE" }); onRefresh(); } catch {}
+          }} />
         )}
         {canResume && steps.length > 0 && (
           <>
@@ -259,16 +269,14 @@ function Label({ children }: { children: string }) {
   return <div className="text-zinc-500 text-xs uppercase mb-1.5">{children}</div>;
 }
 
-function ActionButton({ label, variant, onClick }: { label: string; variant?: "danger"; onClick?: () => void }) {
+function ActionButton({ label, variant, onClick }: { label: string; variant?: "danger" | "muted"; onClick?: () => void }) {
+  const cls = variant === "danger"
+    ? "bg-red-500/10 text-red-400 hover:bg-red-500/20"
+    : variant === "muted"
+      ? "bg-zinc-800 text-zinc-500 hover:bg-zinc-700 hover:text-zinc-300"
+      : "bg-zinc-800 text-zinc-300 hover:bg-zinc-700";
   return (
-    <button
-      onClick={onClick}
-      className={`px-3 py-1.5 rounded text-xs ${
-        variant === "danger"
-          ? "bg-red-500/10 text-red-400 hover:bg-red-500/20"
-          : "bg-zinc-800 text-zinc-300 hover:bg-zinc-700"
-      }`}
-    >
+    <button onClick={onClick} className={`px-3 py-1.5 rounded text-xs ${cls}`}>
       {label}
     </button>
   );

--- a/web/src/components/TaskList.tsx
+++ b/web/src/components/TaskList.tsx
@@ -34,6 +34,7 @@ const STATUS_COLORS: Record<string, string> = {
   active: "bg-blue-900/50 text-blue-400",
   completed: "bg-emerald-900/50 text-emerald-400",
   failed: "bg-red-900/50 text-red-400",
+  closed: "bg-zinc-800 text-zinc-500",
 };
 
 const STATUS_BORDER: Record<string, string> = {
@@ -147,8 +148,8 @@ export default function TaskList({ tasks, trees, paths, getActivity, getActivity
           >
             + New
           </button>
-          {(["all", "active", "failed", "done"] as const).map((f) => {
-            const count = filterCounts[f];
+          {(["all", "active", "failed", "done", "closed"] as const).map((f) => {
+            const count = filterCounts[f as keyof typeof filterCounts];
             const isFailedAlert = f === "failed" && filterCounts.failed > 0 && filter !== "failed";
             return (
               <button
@@ -163,7 +164,7 @@ export default function TaskList({ tasks, trees, paths, getActivity, getActivity
                 }`}
               >
                 {f}
-                <span className="ml-1 text-[10px] opacity-70">({count})</span>
+                {count != null && <span className="ml-1 text-[10px] opacity-70">({count})</span>}
                 {isFailedAlert && <span className="ml-1 text-red-400 animate-pulse">●</span>}
               </button>
             );


### PR DESCRIPTION
## Summary
- Adds `closed` terminal status to `TaskStatus` enum — semantically distinct from `failed` for tasks that are no longer needed
- Close button (muted variant) on draft/failed tasks, Delete button (danger + confirm) on draft tasks
- Closed tasks hidden from default "all" view, visible via dedicated "closed" filter tab
- `close_task` WebSocket handler + `DELETE /api/tasks/:id` REST endpoint (draft-only hard delete)
- Orchestrator and dependency resolution (`getNewlyUnblocked`) exclude closed tasks

Closes #132

## Test plan
- [ ] 7 new tests in `db-close-delete.test.ts` covering close (draft, failed, terminal exclusion, event) and delete (success, not-found, isolation)
- [ ] Verify Close button appears only on draft/failed tasks
- [ ] Verify Delete button appears only on draft tasks with confirmation dialog
- [ ] Verify closed tasks are hidden from default view and visible via "closed" filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)