### PR TITLE
fix: (W-058) fail fast when required skills are missing for result_file steps

### DIFF
--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -9,7 +9,22 @@ import { deploySandbox, deployReviewSandbox, triggerPrompt, resumeTriggerPrompt,
 import type { Database } from "../broker/db";
 import type { Task, Tree, PipelineStep } from "../shared/types";
 import type { AdapterRegistry } from "./adapters/registry";
-import { injectSkills } from "../skills/injector";
+import { injectSkills, type InjectionResult } from "../skills/injector";
+
+/**
+ * Validate that all required skills were injected for a step.
+ * Throws if the step requires a result_file and any skills are missing,
+ * because the worker cannot produce the expected artifact without the skill.
+ */
+export function validateSkillInjection(injection: InjectionResult, step: PipelineStep): void {
+  if (injection.missing.length > 0 && step.result_file) {
+    throw new Error(
+      `Required skills missing for step "${step.id}": ${injection.missing.join(", ")}. ` +
+      `Step expects result_file "${step.result_file}" which requires these skills. ` +
+      `Run "grove up" to bootstrap bundled skills or install manually to ~/.grove/skills/.`
+    );
+  }
+}
 
 export interface WorkerHandle {
   taskId: string;
@@ -59,6 +74,9 @@ export function spawnWorker(task: Task, tree: Tree, db: Database, logDir: string
     if (injection.missing.length > 0) {
       db.addEvent(task.id, null, "skills_missing", `Missing skills: ${injection.missing.join(", ")}`);
     }
+    // Fail fast if the step requires a result_file but skills are missing —
+    // the worker cannot produce the expected artifact without the skill instructions.
+    validateSkillInjection(injection, step);
     if (injection.injected.length > 0) {
       db.addEvent(task.id, null, "skills_injected", `Injected skills: ${injection.injected.join(", ")}`);
     }

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -24,6 +24,14 @@ export async function run(_args: string[]) {
   db.initFromString(SCHEMA_SQL);
   db.close();
 
+  // Install bundled skills (merge-handler, code-review, etc.) into ~/.grove/skills/
+  try {
+    const { bootstrapBundledSkills } = await import("../../skills/library");
+    bootstrapBundledSkills();
+  } catch {
+    // Non-fatal — skills will also be bootstrapped on `grove up`
+  }
+
   console.log(`${pc.green("✓")} Grove initialized at ${pc.bold(GROVE_HOME)}`);
   console.log(`  Config: ${GROVE_CONFIG}`);
   console.log(`  Database: ${GROVE_DB}`);

--- a/src/engine/step-engine.ts
+++ b/src/engine/step-engine.ts
@@ -331,10 +331,16 @@ async function executeStep(
 
   switch (step.type) {
     case "worker": {
-      const { spawnWorker } = await import("../agents/worker");
-      const { getEnv } = await import("../broker/db");
-      const logDir = getEnv().GROVE_LOG_DIR;
-      spawnWorker(task, tree, db, logDir, step);
+      try {
+        const { spawnWorker } = await import("../agents/worker");
+        const { getEnv } = await import("../broker/db");
+        const logDir = getEnv().GROVE_LOG_DIR;
+        spawnWorker(task, tree, db, logDir, step);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        db.addEvent(task.id, null, "worker_spawn_failed", msg);
+        onStepComplete(task.id, "fatal", msg);
+      }
       break;
     }
 

--- a/tests/agents/worker-skills.test.ts
+++ b/tests/agents/worker-skills.test.ts
@@ -1,0 +1,101 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { join } from "node:path";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { injectSkills } from "../../src/skills/injector";
+import { validateSkillInjection } from "../../src/agents/worker";
+import type { PipelineStep } from "../../src/shared/types";
+import type { InjectionResult } from "../../src/skills/injector";
+
+const TEST_DIR = join(tmpdir(), `grove-worker-skills-test-${Date.now()}`);
+const SKILLS_DIR = join(TEST_DIR, "skills");
+
+beforeEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+  mkdirSync(SKILLS_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+function createSkill(name: string) {
+  const dir = join(SKILLS_DIR, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "skill.yaml"), `name: ${name}\nversion: 1.0.0\ndescription: test\nfiles:\n  - skill.md`);
+  writeFileSync(join(dir, "skill.md"), `# ${name}`);
+}
+
+describe("validateSkillInjection", () => {
+  test("throws when skills are missing and step has result_file", () => {
+    const injection: InjectionResult = { injected: [], missing: ["merge-handler"] };
+    const step: PipelineStep = {
+      id: "merge",
+      type: "worker",
+      skills: ["merge-handler"],
+      result_file: ".grove/merge-result.json",
+      result_key: "merged",
+      on_success: "$done",
+      on_failure: "$fail",
+    };
+
+    expect(() => validateSkillInjection(injection, step)).toThrow(/merge-handler/);
+  });
+
+  test("throws with actionable message mentioning 'grove up'", () => {
+    const injection: InjectionResult = { injected: [], missing: ["merge-handler"] };
+    const step: PipelineStep = {
+      id: "merge",
+      type: "worker",
+      skills: ["merge-handler"],
+      result_file: ".grove/merge-result.json",
+      on_success: "$done",
+      on_failure: "$fail",
+    };
+
+    expect(() => validateSkillInjection(injection, step)).toThrow(/grove up/);
+  });
+
+  test("does NOT throw when skills are missing but step has no result_file", () => {
+    const injection: InjectionResult = { injected: [], missing: ["optional-skill"] };
+    const step: PipelineStep = {
+      id: "implement",
+      type: "worker",
+      skills: ["optional-skill"],
+      on_success: "$done",
+      on_failure: "$fail",
+    };
+
+    // Should not throw — missing skill without result_file is a warning, not fatal
+    expect(() => validateSkillInjection(injection, step)).not.toThrow();
+  });
+
+  test("does NOT throw when all skills are present", () => {
+    const injection: InjectionResult = { injected: ["merge-handler"], missing: [] };
+    const step: PipelineStep = {
+      id: "merge",
+      type: "worker",
+      skills: ["merge-handler"],
+      result_file: ".grove/merge-result.json",
+      on_success: "$done",
+      on_failure: "$fail",
+    };
+
+    expect(() => validateSkillInjection(injection, step)).not.toThrow();
+  });
+
+  test("throws listing all missing skills when multiple are missing", () => {
+    const injection: InjectionResult = { injected: [], missing: ["skill-a", "skill-b"] };
+    const step: PipelineStep = {
+      id: "merge",
+      type: "worker",
+      skills: ["skill-a", "skill-b"],
+      result_file: ".grove/merge-result.json",
+      on_success: "$done",
+      on_failure: "$fail",
+    };
+
+    expect(() => validateSkillInjection(injection, step)).toThrow(/skill-a/);
+    expect(() => validateSkillInjection(injection, step)).toThrow(/skill-b/);
+  });
+});

--- a/tests/engine/step-engine-skills.test.ts
+++ b/tests/engine/step-engine-skills.test.ts
@@ -1,0 +1,121 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { createTestDb } from "../fixtures/helpers";
+import { bus } from "../../src/broker/event-bus";
+import type { Database } from "../../src/broker/db";
+
+// ---------------------------------------------------------------------------
+// Test paths: merge step has result_file + skills (like the real config)
+// ---------------------------------------------------------------------------
+
+const TEST_PATHS = {
+  development: {
+    description: "Standard dev workflow",
+    steps: [
+      { id: "implement", type: "worker" as const, on_success: "merge", on_failure: "$fail", label: "Implement" },
+      { id: "merge", type: "worker" as const, skills: ["merge-handler"], result_file: ".grove/merge-result.json", result_key: "merged", on_success: "$done", on_failure: "$fail", label: "Merge" },
+    ],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Mocks — spawnWorker throws when step has result_file + skills
+// ---------------------------------------------------------------------------
+
+const _realConfig = await import("../../src/broker/config");
+const _realWorker = await import("../../src/agents/worker");
+
+let shouldThrow = false;
+
+mock.module("../../src/broker/config", () => ({
+  ..._realConfig,
+  configNormalizedPaths: () => TEST_PATHS,
+}));
+
+mock.module("../../src/agents/worker", () => ({
+  ..._realWorker,
+  spawnWorker: mock((...args: any[]) => {
+    if (shouldThrow) {
+      throw new Error('Required skills missing for step "merge": merge-handler. Run "grove up" to bootstrap bundled skills.');
+    }
+  }),
+}));
+
+const { startPipeline, onStepComplete, _setDb } = await import("../../src/engine/step-engine");
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("step engine handles spawnWorker errors", () => {
+  let db: Database;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.db;
+    cleanup = t.cleanup;
+    db.treeUpsert({ id: "tree-1", name: "Test Tree", path: "/tmp/test-tree" });
+    _setDb(db);
+    shouldThrow = false;
+  });
+
+  afterEach(async () => {
+    bus.removeAll();
+    shouldThrow = false;
+    await new Promise((r) => setTimeout(r, 10));
+    cleanup();
+  });
+
+  function createTaskAt(id: string, step: string, stepIndex: number, opts: { retry_count?: number; max_retries?: number } = {}) {
+    db.run(
+      `INSERT INTO tasks (id, title, status, tree_id, path_name, current_step, step_index, retry_count, max_retries)
+       VALUES (?, ?, 'active', 'tree-1', 'development', ?, ?, ?, ?)`,
+      [id, `Task ${id}`, step, stepIndex, opts.retry_count ?? 0, opts.max_retries ?? 2],
+    );
+  }
+
+  test("when spawnWorker throws, task fails fatally (no retries)", async () => {
+    createTaskAt("T-SKL-001", "implement", 0, { retry_count: 0, max_retries: 2 });
+    shouldThrow = true;
+
+    onStepComplete("T-SKL-001", "success"); // implement succeeds → transitions to merge → spawnWorker throws
+
+    // Wait for async executeStep to complete
+    await new Promise((r) => setTimeout(r, 50));
+
+    const updated = db.taskGet("T-SKL-001");
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe("failed");
+    expect(updated!.current_step).toBe("$fail");
+    // retry_count should NOT be incremented — fatal skips retries
+    expect(updated!.retry_count).toBe(0);
+  });
+
+  test("when spawnWorker throws, actionable error is logged as event", async () => {
+    createTaskAt("T-SKL-002", "implement", 0, { retry_count: 0, max_retries: 2 });
+    shouldThrow = true;
+
+    onStepComplete("T-SKL-002", "success"); // implement succeeds → merge → throw
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const events = db.eventsByTask("T-SKL-002");
+    const failEvent = events.find(e => e.event_type === "task_failed");
+    expect(failEvent).toBeDefined();
+    expect(failEvent!.summary).toContain("skills missing");
+  });
+
+  test("when spawnWorker succeeds, task proceeds normally", async () => {
+    createTaskAt("T-SKL-003", "implement", 0);
+    shouldThrow = false;
+
+    onStepComplete("T-SKL-003", "success");
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const updated = db.taskGet("T-SKL-003")!;
+    // Task should be at merge step (transitioned from implement)
+    expect(updated.current_step).toBe("merge");
+    expect(updated.status).toBe("active");
+  });
+});


### PR DESCRIPTION
## Summary

- Worker now validates all required skills are injected before spawning — if a step declares both `skills` and `result_file`, missing skills trigger an immediate error instead of spawning a doomed worker
- Step engine wraps `spawnWorker` in try-catch and reports `"fatal"` outcome (bypasses retries) on spawn failure
- `grove init` now calls `bootstrapBundledSkills()` so bundled skills are available immediately

## Test plan

- [ ] `worker-skills.test.ts` — validates fail-fast on missing skills
- [ ] `step-engine-skills.test.ts` — validates fatal outcome bypasses retries
- [ ] Manual: `grove init` installs merge-handler, code-review, adversarial-review, research-report to `~/.grove/skills/`

Closes #139
Relates to #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)