### PR TITLE
fix: prevent task detail scroll jump on new activity events

### DIFF
--- a/web/src/components/SeedChat.tsx
+++ b/web/src/components/SeedChat.tsx
@@ -9,7 +9,7 @@ interface Props {
   messages: SeedMessage[];
   isActive: boolean;
   isSeeded: boolean;
-  bottomRef: RefObject<HTMLDivElement | null>;
+  containerRef: RefObject<HTMLDivElement | null>;
   taskId?: string;
   taskTitle?: string;
   streamingText?: string;
@@ -49,7 +49,7 @@ function HtmlFragment({ html, onChoice }: { html: string; onChoice: (value: stri
   );
 }
 
-export default function SeedChat({ seed, messages, isActive, isSeeded, bottomRef, taskId, taskTitle, streamingText, stage, branches, activeBranch, wsSend, onSend, onStart, onStop, onDiscard }: Props) {
+export default function SeedChat({ seed, messages, isActive, isSeeded, containerRef, taskId, taskTitle, streamingText, stage, branches, activeBranch, wsSend, onSend, onStart, onStop, onDiscard }: Props) {
   const [input, setInput] = useState("");
   const [expanded, setExpanded] = useState(false);
 
@@ -155,7 +155,7 @@ export default function SeedChat({ seed, messages, isActive, isSeeded, bottomRef
       )}
 
       {/* Messages */}
-      <div className="max-h-80 overflow-y-auto p-3 space-y-2">
+      <div ref={containerRef} className="max-h-80 overflow-y-auto p-3 space-y-2">
         {/* Welcome guidance when no messages yet */}
         {messages.length === 0 && (
           <div className="text-center py-4 space-y-2">
@@ -206,7 +206,6 @@ export default function SeedChat({ seed, messages, isActive, isSeeded, bottomRef
             </div>
           </div>
         ) : null}
-        <div ref={bottomRef} />
       </div>
 
       {/* Input */}

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -26,7 +26,7 @@ interface Props {
   seedMessages?: SeedMessage[];
   seedActive?: boolean;
   seedComplete?: boolean;
-  seedBottomRef?: React.RefObject<HTMLDivElement | null>;
+  seedContainerRef?: React.RefObject<HTMLDivElement | null>;
   onSeedSend?: (text: string) => void;
   onSeedStart?: () => void;
   onSeedStop?: () => void;
@@ -37,7 +37,7 @@ interface Props {
   seedActiveBranch?: string;
 }
 
-export default function TaskDetail({ task, activityLog, steps, send, trees, paths, allTasks, onRefresh, seed, seedMessages, seedActive, seedComplete, seedBottomRef, onSeedSend, onSeedStart, onSeedStop, onSeedDiscard, seedStreamingText, seedStage, seedBranches, seedActiveBranch }: Props) {
+export default function TaskDetail({ task, activityLog, steps, send, trees, paths, allTasks, onRefresh, seed, seedMessages, seedActive, seedComplete, seedContainerRef, onSeedSend, onSeedStart, onSeedStop, onSeedDiscard, seedStreamingText, seedStage, seedBranches, seedActiveBranch }: Props) {
   const gateResults = task.gate_results ? JSON.parse(task.gate_results) : null;
   const filesModified = task.files_modified?.split("\n").filter(Boolean) ?? [];
   const [resumeStep, setResumeStep] = useState(task.current_step ?? steps[0]?.id ?? "");
@@ -118,7 +118,7 @@ export default function TaskDetail({ task, activityLog, steps, send, trees, path
             messages={seedMessages ?? []}
             isActive={seedActive ?? false}
             isSeeded={seedComplete ?? false}
-            bottomRef={seedBottomRef ?? { current: null }}
+            containerRef={seedContainerRef ?? { current: null }}
             taskId={task.id}
             taskTitle={task.title}
             streamingText={seedStreamingText}
@@ -143,7 +143,7 @@ export default function TaskDetail({ task, activityLog, steps, send, trees, path
             messages={[]}
             isActive={false}
             isSeeded={true}
-            bottomRef={{ current: null }}
+            containerRef={{ current: null }}
             onSend={() => {}}
             onStart={() => {}}
             onStop={() => {}}

--- a/web/src/components/TaskList.tsx
+++ b/web/src/components/TaskList.tsx
@@ -296,7 +296,7 @@ export default function TaskList({ tasks, trees, paths, getActivity, getActivity
                 seedMessages={seedState.messages}
                 seedActive={seedState.isActive}
                 seedComplete={seedState.isSeeded}
-                seedBottomRef={seedState.bottomRef}
+                seedContainerRef={seedState.containerRef}
                 onSeedSend={seedState.sendMessage}
                 onSeedStart={seedState.startSeed}
                 onSeedStop={seedState.stopSeed}

--- a/web/src/components/WorkerActivityFeed.tsx
+++ b/web/src/components/WorkerActivityFeed.tsx
@@ -52,13 +52,16 @@ export default function WorkerActivityFeed({ log, taskStatus, paused: taskPaused
 // ---------------------------------------------------------------------------
 
 function LiveFeed({ log, live, since }: { log: ActivityEntry[]; live: boolean; since?: string | null }) {
-  const bottomRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const [paused, setPaused] = useState(false);
   const [pinnedLength, setPinnedLength] = useState(0);
 
+  // Scroll only the feed container — NOT ancestor scroll containers.
+  // (scrollIntoView bubbles up to every scrollable ancestor, which
+  //  caused the entire TaskDetail to jump to the bottom on each event.)
   useEffect(() => {
-    if (!paused) {
-      bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    if (!paused && containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
     }
   }, [log.length, paused]);
 
@@ -79,7 +82,7 @@ function LiveFeed({ log, live, since }: { log: ActivityEntry[]; live: boolean; s
           </button>
         )}
       </div>
-      <div className="bg-zinc-950 border border-zinc-800 rounded-lg p-2 max-h-48 overflow-y-auto font-mono text-[11px] leading-relaxed">
+      <div ref={containerRef} className="bg-zinc-950 border border-zinc-800 rounded-lg p-2 max-h-48 overflow-y-auto font-mono text-[11px] leading-relaxed">
         {displayLog.length === 0 && live && (
           <div className="text-blue-400/70 text-center py-3">
             <ActivityIndicator since={since} label="Waiting for activity" size="md" />
@@ -93,7 +96,6 @@ function LiveFeed({ log, live, since }: { log: ActivityEntry[]; live: boolean; s
             <ActivityIndicator since={displayLog[displayLog.length - 1]?.ts} />
           </div>
         )}
-        <div ref={bottomRef} />
       </div>
     </Section>
   );

--- a/web/src/hooks/useSeed.ts
+++ b/web/src/hooks/useSeed.ts
@@ -31,7 +31,7 @@ export function useSeed(taskId: string | null, send: (data: any) => void) {
   const [stage, setStage] = useState<string | null>(null);
   const [branches, setBranches] = useState<SeedBranchInfo[]>([]);
   const [activeBranch, setActiveBranch] = useState("main");
-  const bottomRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const loadSeed = useCallback(async (tid: string) => {
     setLoading(true);
@@ -138,12 +138,15 @@ export function useSeed(taskId: string | null, send: (data: any) => void) {
     }
   }, [taskId]);
 
+  // Scroll only the messages container, not ancestor scroll containers
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    if (containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
   }, [messages.length, streamingText]);
 
   return {
-    seed, messages, loading, bottomRef, streamingText, stage,
+    seed, messages, loading, containerRef, streamingText, stage,
     branches, activeBranch,
     startSeed, stopSeed, sendMessage, discardSeed, handleWsMessage,
     isActive: seed?.active ?? false,


### PR DESCRIPTION
## Summary
- Replace `scrollIntoView()` with `container.scrollTop = container.scrollHeight` in `WorkerActivityFeed` and `useSeed` hook
- `scrollIntoView` was bubbling up to every ancestor `overflow-y-auto` container, causing the entire TaskDetail panel to jump to the bottom each time the activity stream received a new event
- Same fix applied to SeedChat (brainstorm) which had the identical pattern inside TaskDetail

## Test plan
- [ ] Expand a task with an active worker — activity feed should auto-scroll within its own box without moving the task detail view
- [ ] Scroll up in task detail while activity is streaming — position should stay put
- [ ] Click Pause on activity feed — verify it still freezes correctly
- [ ] Open a brainstorm session — verify messages auto-scroll within the chat box without jumping the parent

🤖 Generated with [Claude Code](https://claude.com/claude-code)