### PR TITLE
fix: persist PR details from merge-handler result

### DIFF
--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -327,6 +327,14 @@ async function monitorWorker(handle: WorkerHandle, db: Database): Promise<void> 
           const key = currentStep.result_key ?? "approved";
           outcome = result[key] ? "success" : "failure";
           context = result.feedback ?? result.reason;
+
+          // Persist PR details from merge result so downstream events carry them
+          const prNum = typeof result.pr_number === "number" ? result.pr_number : null;
+          const prUrl = typeof result.pr_url === "string" ? result.pr_url : null;
+          if (prNum && prUrl) {
+            db.run("UPDATE tasks SET pr_number = ?, pr_url = ? WHERE id = ?", [prNum, prUrl, taskId]);
+            bus.emit("merge:pr_created", { taskId, prNumber: prNum, prUrl });
+          }
         } catch {
           outcome = "failure";
           context = `Failed to parse result file: ${currentStep.result_file}`;


### PR DESCRIPTION
## Summary

- After the v0.2.0 migration to agent-based merge steps, `worker.ts` only read the `merged` boolean from `merge-result.json` — it never extracted `pr_number`/`pr_url` or emitted `merge:pr_created`
- This left task records with null PR fields and starved 6 downstream event consumers (`watch-core`, WebSocket forward, `orchestrator-feedback`, notifications)
- Now reads `pr_number` and `pr_url` from the merge result file, persists to DB before `onStepComplete` (so `merge:completed` also carries the correct PR number), and emits `merge:pr_created`

## Root cause

The deleted `src/merge/manager.ts` (v0.2.0, PR #138) was responsible for calling `ghPrCreate()` natively and recording PR details. The replacement agent-based merge step writes these fields to `.grove/merge-result.json`, but the broker never read them back.

## Test plan

- [x] 651 tests pass, 0 fail
- [ ] Run a pipeline end-to-end and verify `grove tasks` shows PR number/URL
- [ ] Verify `merge:pr_created` event appears in WebSocket stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)