### PR TITLE
feat: (W-065) task status never syncs back from GitHub issue closure

### DIFF
--- a/.grove/session-summary.md
+++ b/.grove/session-summary.md
@@ -1,37 +1,37 @@
-# Session Summary: W-061
+# Session Summary: W-065
 
 ## Summary
 
-Implemented the Skills Library UI in the Settings page (issue #142). Added a new "Skills Library" section between Trees and Budget that lets users browse installed skills, install new ones from local paths or Git URLs, and remove existing skills with confirmation. The UI subscribes to `skill:installed` and `skill:removed` WebSocket events for real-time updates.
+Implemented an issue-status poller that periodically checks GitHub for closed issues and updates the corresponding local task status to `closed`. This closes the sync gap where GitHub issue closures (manual, merged PR, or @claude) were never reflected in the Grove task database.
+
+The poller follows the same architectural pattern as the existing PR poller: a start/stop module with an interval-based poll loop, wired into the broker startup/shutdown lifecycle. It batches API calls by repository to minimize `gh` CLI invocations.
 
 ## Changes Made
 
-### API Client (`web/src/api/client.ts`)
-- Added `SkillManifest` interface (frontend copy of server type)
-- Added `fetchSkills()`, `installSkill(source)`, and `removeSkill(name)` API functions
+### `src/shared/github.ts`
+- Added `ghIssueView()` — fetch a single issue by number
+- Added `ghIssueStatuses()` — batch-fetch issue states for a list of issue numbers within a repo (groups results from `ghIssueList`)
 
-### useSkills Hook (`web/src/hooks/useSkills.ts`) — NEW
-- Fetches skills list on mount via `GET /api/skills`
-- Re-fetches on `skill:installed` / `skill:removed` WebSocket events
-- Exposes `install` and `remove` actions
+### `src/broker/db.ts`
+- Added `tasksWithOpenIssues()` — query for tasks with a non-null `github_issue` and non-terminal status (`draft`, `queued`, `active`), joined to their tree for the GitHub repo URL
 
-### App (`web/src/App.tsx`)
-- Imported and instantiated `useSkills` hook
-- Wired `skillsState.handleWsMessage` into the WebSocket message handler
-- Passed skills state props to both Settings instances (mobile + desktop)
+### `src/broker/issue-poller.ts` — NEW
+- `startIssuePoller(db)` — polls every 5 minutes, groups tasks by repo, calls `ghIssueStatuses`, marks closed issues as `closed` with `completed_at`, emits `task:status` bus event
+- `stopIssuePoller()` — clears the interval
 
-### Settings (`web/src/components/Settings.tsx`)
-- Added Skills Library section with:
-  - Card per installed skill showing name, version, description, author, file count, and suggested steps
-  - Install form (unified input for local path or Git URL)
-  - Remove button with inline two-step confirmation
-  - Loading and error states
+### `src/broker/index.ts`
+- Wired `startIssuePoller(db)` at broker startup (after PR poller)
+- Wired `stopIssuePoller()` at broker shutdown
+
+### `tests/broker/issue-poller.test.ts` — NEW
+- 5 tests covering `tasksWithOpenIssues()`: non-terminal statuses returned, terminal statuses excluded, null github_issue excluded, trees without github excluded, multi-repo grouping
 
 ## Files Modified
-- `web/src/api/client.ts` — skill API functions and SkillManifest type
-- `web/src/hooks/useSkills.ts` — new hook file
-- `web/src/App.tsx` — useSkills wiring + Settings props
-- `web/src/components/Settings.tsx` — Skills Library section
+- `src/shared/github.ts` — ghIssueView + ghIssueStatuses helpers
+- `src/broker/db.ts` — tasksWithOpenIssues query
+- `src/broker/issue-poller.ts` — new poller module
+- `src/broker/index.ts` — wiring
+- `tests/broker/issue-poller.test.ts` — new test file
 
 ## Next Steps
-- None — feature is complete as specified in issue #142
+- None — feature is complete as specified in issue #156

--- a/src/broker/db.ts
+++ b/src/broker/db.ts
@@ -206,6 +206,18 @@ export class Database {
     return candidates.filter(t => !this.isTaskBlocked(t.id));
   }
 
+  /** Find tasks with a github_issue that are still in a non-terminal status, grouped by tree */
+  tasksWithOpenIssues(): Array<{ tree_id: string; github: string; task_id: string; github_issue: number }> {
+    return this.all(
+      `SELECT t.id AS task_id, t.tree_id, t.github_issue, tr.github
+       FROM tasks t
+       JOIN trees tr ON t.tree_id = tr.id
+       WHERE t.github_issue IS NOT NULL
+         AND t.status NOT IN ('completed', 'failed', 'closed')
+         AND tr.github IS NOT NULL`,
+    );
+  }
+
   subTasks(parentTaskId: string): Task[] {
     return this.all<Task>(
       "SELECT * FROM tasks WHERE parent_task_id = ? ORDER BY created_at ASC",

--- a/src/broker/index.ts
+++ b/src/broker/index.ts
@@ -19,6 +19,7 @@ import { wireNotifications } from "../notifications/index";
 import { wireGitHubSync } from "./github-sync";
 import { wireOrchestratorFeedback, unwireOrchestratorFeedback } from "./orchestrator-feedback";
 import { startPrPoller, stopPrPoller } from "../pr/poller";
+import { startIssuePoller, stopIssuePoller } from "./issue-poller";
 import { PluginHost } from "../plugins/host";
 import { setAdapterRegistry } from "../agents/worker";
 import { AdapterRegistry } from "../agents/adapters/registry";
@@ -145,6 +146,9 @@ export async function startBroker(): Promise<BrokerInfo> {
   // Start PR poller (polls GitHub for new PRs per tree)
   startPrPoller(db);
 
+  // Start issue-status poller (syncs task status from GitHub issue closures)
+  startIssuePoller(db);
+
   // Initialize orchestrator and wire event feedback loop
   orchestrator.init(db);
   wireOrchestratorFeedback(db);
@@ -221,6 +225,7 @@ export async function startBroker(): Promise<BrokerInfo> {
     stopCostMonitor();
     stopHeartbeat();
     stopPrPoller();
+    stopIssuePoller();
     pluginHost?.shutdown().catch(() => {});
     // Deregister from grove.cloud (best-effort, non-blocking)
     const tc = tunnelConfig();

--- a/src/broker/issue-poller.ts
+++ b/src/broker/issue-poller.ts
@@ -1,0 +1,63 @@
+// Grove v3 — Issue-status poller: sync task status from GitHub issue closure
+import { bus } from "./event-bus";
+import type { Database } from "./db";
+
+let _interval: ReturnType<typeof setInterval> | null = null;
+
+const POLL_INTERVAL = 300_000; // 5 minutes
+
+/** Start polling GitHub for closed issues and update local task status */
+export function startIssuePoller(db: Database): void {
+  if (_interval) return;
+
+  const poll = async () => {
+    const rows = db.tasksWithOpenIssues();
+    if (rows.length === 0) return;
+
+    // Group by repo to batch API calls
+    const byRepo = new Map<string, Array<{ task_id: string; github_issue: number }>>();
+    for (const row of rows) {
+      const list = byRepo.get(row.github) ?? [];
+      list.push({ task_id: row.task_id, github_issue: row.github_issue });
+      byRepo.set(row.github, list);
+    }
+
+    for (const [repo, tasks] of byRepo) {
+      try {
+        const { ghIssueStatuses } = await import("../shared/github");
+        const issueNumbers = tasks.map(t => t.github_issue);
+        const statuses = ghIssueStatuses(repo, issueNumbers);
+
+        for (const task of tasks) {
+          const state = statuses.get(task.github_issue);
+          if (state === "CLOSED") {
+            db.run(
+              "UPDATE tasks SET status = 'closed', completed_at = datetime('now') WHERE id = ?",
+              [task.task_id],
+            );
+            db.addEvent(
+              task.task_id,
+              null,
+              "status_change",
+              `Status changed to closed (GitHub issue #${task.github_issue} was closed)`,
+            );
+            bus.emit("task:status", { taskId: task.task_id, status: "closed" });
+          }
+        }
+      } catch (err: any) {
+        db.addEvent(null, null, "issue_poll_error", `Issue poll failed for ${repo}: ${err.message}`);
+      }
+    }
+  };
+
+  poll();
+  _interval = setInterval(poll, POLL_INTERVAL);
+}
+
+/** Stop the issue-status poller */
+export function stopIssuePoller(): void {
+  if (_interval) {
+    clearInterval(_interval);
+    _interval = null;
+  }
+}

--- a/src/shared/github.ts
+++ b/src/shared/github.ts
@@ -263,6 +263,36 @@ export function ghIssueClose(repo: string, issueNumber: number): boolean {
   return result.ok;
 }
 
+/** Fetch a single issue by number. Returns null if the issue doesn't exist or gh fails. */
+export function ghIssueView(repo: string, issueNumber: number): GhIssue | null {
+  const result = gh([
+    "issue", "view", String(issueNumber), "-R", repo,
+    "--json", "number,title,state,url,body,labels",
+  ]);
+  if (!result.ok) return null;
+  try { return JSON.parse(result.stdout); } catch { return null; }
+}
+
+/**
+ * Batch-fetch the state of multiple issues in a single `gh issue list` call.
+ * Returns a map of issue number → state string ("OPEN" or "CLOSED").
+ * Issues not found in the result are omitted from the map.
+ */
+export function ghIssueStatuses(repo: string, issueNumbers: number[]): Map<number, string> {
+  if (issueNumbers.length === 0) return new Map();
+  // Use gh issue list with --state=all and a high limit to fetch all relevant issues.
+  // Then filter client-side to only the numbers we care about.
+  const issues = ghIssueList(repo, { state: "all", limit: 200 });
+  const wanted = new Set(issueNumbers);
+  const result = new Map<number, string>();
+  for (const issue of issues) {
+    if (wanted.has(issue.number)) {
+      result.set(issue.number, issue.state);
+    }
+  }
+  return result;
+}
+
 export function ghIssueList(repo: string, opts?: { state?: string; limit?: number }): GhIssue[] {
   const args = [
     "issue", "list", "-R", repo,

--- a/tests/broker/issue-poller.test.ts
+++ b/tests/broker/issue-poller.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { createTestDb } from "../fixtures/helpers";
+import type { Database } from "../../src/broker/db";
+
+describe("issue-poller", () => {
+  let db: Database;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    ({ db, cleanup } = createTestDb());
+    db.treeUpsert({
+      id: "my-app",
+      name: "my-app",
+      path: "/tmp/my-app",
+      github: "owner/my-app",
+      branch_prefix: "grove/",
+    });
+    db.treeUpsert({
+      id: "other-app",
+      name: "other-app",
+      path: "/tmp/other-app",
+      github: "owner/other-app",
+      branch_prefix: "grove/",
+    });
+  });
+
+  afterEach(() => cleanup());
+
+  describe("tasksWithOpenIssues", () => {
+    test("returns tasks with github_issue and non-terminal status", () => {
+      db.run(
+        "INSERT INTO tasks (id, tree_id, title, path_name, status, github_issue) VALUES (?, ?, ?, ?, ?, ?)",
+        ["W-001", "my-app", "Open task", "development", "draft", 10],
+      );
+      db.run(
+        "INSERT INTO tasks (id, tree_id, title, path_name, status, github_issue) VALUES (?, ?, ?, ?, ?, ?)",
+        ["W-002", "my-app", "Active task", "development", "active", 11],
+      );
+      db.run(
+        "INSERT INTO tasks (id, tree_id, title, path_name, status, github_issue) VALUES (?, ?, ?, ?, ?, ?)",
+        ["W-003", "my-app", "Queued task", "development", "queued", 12],
+      );
+
+      const rows = db.tasksWithOpenIssues();
+      expect(rows).toHaveLength(3);
+      expect(rows.map(r => r.task_id).sort()).toEqual(["W-001", "W-002", "W-003"]);
+      expect(rows[0].github).toBe("owner/my-app");
+    });
+
+    test("excludes tasks with terminal statuses", () => {
+      db.run(
+        "INSERT INTO tasks (id, tree_id, title, path_name, status, github_issue) VALUES (?, ?, ?, ?, ?, ?)",
+        ["W-001", "my-app", "Completed task", "development", "completed", 10],
+      );
+      db.run(
+        "INSERT INTO tasks (id, tree_id, title, path_name, status, github_issue) VALUES (?, ?, ?, ?, ?, ?)",
+        ["W-002", "my-app", "Failed task", "development", "failed", 11],
+      );
+      db.run(
+        "INSERT INTO tasks (id, tree_id, title, path_name, status, github_issue) VALUES (?, ?, ?, ?, ?, ?)",
+        ["W-003", "my-app", "Closed task", "development", "closed", 12],
+      );
+
+      const rows = db.tasksWithOpenIssues();
+      expect(rows).toHaveLength(0);
+    });
+
+    test("excludes tasks without github_issue", () => {
+      db.run(
+        "INSERT INTO tasks (id, tree_id, title, path_name, status) VALUES (?, ?, ?, ?, ?)",
+        ["W-001", "my-app", "No issue", "development", "draft"],
+      );
+
+      const rows = db.tasksWithOpenIssues();
+      expect(rows).toHaveLength(0);
+    });
+
+    test("excludes tasks whose tree has no github configured", () => {
+      db.treeUpsert({ id: "local", name: "local", path: "/tmp/local" });
+      db.run(
+        "INSERT INTO tasks (id, tree_id, title, path_name, status, github_issue) VALUES (?, ?, ?, ?, ?, ?)",
+        ["W-001", "local", "Local task", "development", "draft", 10],
+      );
+
+      const rows = db.tasksWithOpenIssues();
+      expect(rows).toHaveLength(0);
+    });
+
+    test("groups correctly across multiple repos", () => {
+      db.run(
+        "INSERT INTO tasks (id, tree_id, title, path_name, status, github_issue) VALUES (?, ?, ?, ?, ?, ?)",
+        ["W-001", "my-app", "Task A", "development", "draft", 10],
+      );
+      db.run(
+        "INSERT INTO tasks (id, tree_id, title, path_name, status, github_issue) VALUES (?, ?, ?, ?, ?, ?)",
+        ["W-002", "other-app", "Task B", "development", "active", 20],
+      );
+
+      const rows = db.tasksWithOpenIssues();
+      expect(rows).toHaveLength(2);
+      const repos = rows.map(r => r.github).sort();
+      expect(repos).toEqual(["owner/my-app", "owner/other-app"]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds an **issue-status poller** that periodically checks GitHub for closed issues and updates the corresponding local task status to `closed`. This closes the sync gap where GitHub issue closures (manual, merged PR, or @claude) were never reflected in the Grove task database.

The poller follows the same architectural pattern as the existing PR poller: a start/stop module with an interval-based poll loop, wired into the broker startup/shutdown lifecycle. It batches API calls by repository to minimize `gh` CLI invocations.

## Changes

- **`src/shared/github.ts`** — Added `ghIssueView()` and `ghIssueStatuses()` helpers for fetching issue state
- **`src/broker/db.ts`** — Added `tasksWithOpenIssues()` query for tasks with non-null `github_issue` and non-terminal status
- **`src/broker/issue-poller.ts`** — New poller module: polls every 5 min, groups tasks by repo, marks closed issues as `closed` with `completed_at`, emits `task:status` bus event
- **`src/broker/index.ts`** — Wired poller into broker startup/shutdown
- **`tests/broker/issue-poller.test.ts`** — 5 tests covering the `tasksWithOpenIssues` query

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)