### PR TITLE
fix: remove contradictory push restriction from merge worker sandbox

### DIFF
--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -163,6 +163,7 @@ export function spawnWorker(task: Task, tree: Tree, db: Database, logDir: string
       reviewFeedback,
       checkpoint: checkpointCtx,
       sandbox: step?.sandbox ?? "read-write",
+      stepId: step?.id,
     });
   }
 

--- a/src/engine/step-engine.ts
+++ b/src/engine/step-engine.ts
@@ -164,6 +164,14 @@ export function onStepComplete(
 
   // --- $done ---
   if (target === "$done") {
+    // Guard: merge steps must produce a PR before the task can complete.
+    // Re-read task to pick up pr_number written by monitorWorker just before this call.
+    const freshTask = db.taskGet(taskId);
+    if (currentStep.result_key === "merged" && !freshTask?.pr_number) {
+      failTask(db, taskId, `Merge step completed but no PR was created — worker may have skipped git push`);
+      return;
+    }
+
     db.run(
       "UPDATE tasks SET status = 'completed', current_step = '$done', completed_at = datetime('now') WHERE id = ?",
       [taskId],

--- a/src/shared/sandbox.ts
+++ b/src/shared/sandbox.ts
@@ -55,6 +55,7 @@ export interface OverlayContext {
     costSoFar: number;
   } | null;
   sandbox?: "read-write" | "read-only";
+  stepId?: string;
 }
 
 export interface ReviewOverlayContext {
@@ -175,7 +176,9 @@ export function buildOverlay(ctx: OverlayContext): string {
   }
   parts.push("- Run tests if available before marking done");
   parts.push("- Write the session summary file before finishing");
-  parts.push("- Do NOT push to remote — Grove handles that");
+  if (ctx.stepId !== "merge") {
+    parts.push("- Do NOT push to remote — Grove handles that");
+  }
 
   return parts.join("\n");
 }


### PR DESCRIPTION
## Summary
- Merge workers received "Do NOT push to remote" in their CLAUDE.md Working Guidelines, directly contradicting the merge-handler skill's instructions to `git push` and `gh pr create`. Workers obeyed the guideline and silently skipped PR creation.
- `onStepComplete` had no guard checking whether `pr_url` was populated, so tasks reached `completed` status with no PR.
- This caused W-064 and W-065 to "complete" without creating PRs.

## Changes
- **`src/shared/sandbox.ts`** — Add `stepId` to `OverlayContext`; skip the "Do NOT push" line when `stepId === "merge"`
- **`src/agents/worker.ts`** — Pass `step?.id` into `deploySandbox` context
- **`src/engine/step-engine.ts`** — Fail merge steps that complete without a `pr_number` (defense-in-depth)

## Test plan
- [x] All 651 existing tests pass
- [ ] Spawn a new task through the development path and verify the merge worker creates a PR
- [ ] Verify non-merge workers still see "Do NOT push to remote" in their CLAUDE.md overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)