### PR TITLE
TUI: reorganize sidebar status bar to 3 columns × 2 rows

### DIFF
--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -125,13 +125,13 @@ export default function Sidebar({ trees, status, taskCount, treeCounts, selected
 
       {/* Compact Status Bar */}
       <div className="mt-auto pt-3 border-t border-zinc-800/50">
-        <div className="flex items-center justify-between text-xs text-zinc-500">
+        <div className="grid grid-cols-3 gap-x-3 gap-y-0.5 text-xs text-zinc-500">
           <div className="flex items-center gap-2">
             <span>Broker</span>
             <span className={`inline-block w-1.5 h-1.5 rounded-full ${status?.broker === "running" ? "bg-emerald-400" : "bg-red-400"}`} />
           </div>
           <span>Workers {status?.workers ?? 0}</span>
-          <span>Today ${(status?.cost.today ?? 0).toFixed(2)}</span>
+          <span className="text-right">Today ${(status?.cost.today ?? 0).toFixed(2)}</span>
           {status?.version && <span className="text-zinc-600">v{status.version}</span>}
         </div>
         {status?.remoteUrl && (


### PR DESCRIPTION
## Summary

Reorganized the sidebar status bar from a single-row `flex justify-between` layout (4 columns) to a `grid grid-cols-3` layout (3 columns × 2 rows).

**Before:** `| Broker 🟢 | Workers 2 | Today $1.45 | v0.x.x |`
**After:**
| Broker 🟢 | Workers 2 | Today $1.45 |
|---|---|---|
| v0.x.x | | |

### Changes
- Changed status bar container from `flex items-center justify-between` to `grid grid-cols-3 gap-x-3 gap-y-0.5`
- Added `text-right` to the "Today" cost column for proper alignment
- Grid auto-flows the version span into row 2, col 1 (beneath broker)

### Files Modified
- `web/src/components/Sidebar.tsx` — status bar layout

Closes #159