### PR TITLE
Full pipeline CRUD — CLI commands and REST API for create/read/update/delete paths

### DIFF
--- a/src/broker/server.ts
+++ b/src/broker/server.ts
@@ -112,6 +112,11 @@ function wireEventBus(db: Database) {
   forward("skill:installed");
   forward("skill:removed");
 
+  // Path management events
+  forward("path:created");
+  forward("path:updated");
+  forward("path:deleted");
+
   // Clear ring buffer when worker finishes
   bus.on("worker:ended", (data) => {
     activityBuffer.clear(data.taskId);
@@ -563,6 +568,7 @@ async function handleApi(
       const errors = validatePathConfig({ description: body.description ?? "", steps: body.steps ?? [] });
       if (errors.length > 0) return json({ error: "Validation failed", details: errors }, 400);
       configSetPath(body.name, { description: body.description!, steps: body.steps! });
+      bus.emit("path:created", { name: body.name });
       const { configNormalizedPathsForApi } = await import("./config");
       return json(configNormalizedPathsForApi()[body.name], 201);
     }
@@ -579,6 +585,7 @@ async function handleApi(
       const errors = validatePathConfig({ description: body.description ?? "", steps: body.steps ?? [] });
       if (errors.length > 0) return json({ error: "Validation failed", details: errors }, 400);
       configSetPath(name, { description: body.description!, steps: body.steps! });
+      bus.emit("path:updated", { name });
       const { configNormalizedPathsForApi } = await import("./config");
       return json(configNormalizedPathsForApi()[name]);
     }
@@ -592,6 +599,7 @@ async function handleApi(
       const existing = getPaths();
       if (!(name in existing)) return json({ error: "Path not found" }, 404);
       configDeletePath(name);
+      bus.emit("path:deleted", { name });
       return json({ ok: true });
     }
 

--- a/src/cli/commands/paths.ts
+++ b/src/cli/commands/paths.ts
@@ -1,0 +1,400 @@
+// grove paths — List paths / grove path show|add|remove|export|import
+import { readFileSync, writeFileSync } from "node:fs";
+import pc from "picocolors";
+import { readBrokerInfo } from "../../broker/index";
+import { DEFAULT_PATHS } from "../../shared/types";
+import type { NormalizedPathConfig, PathConfig } from "../../shared/types";
+
+export async function run(args: string[]) {
+  const sub = args[0];
+
+  if (sub === "show")   return showPath(args.slice(1));
+  if (sub === "add")    return addPath(args.slice(1));
+  if (sub === "remove") return removePath(args.slice(1));
+  if (sub === "export") return exportPath(args.slice(1));
+  if (sub === "import") return importPath(args.slice(1));
+
+  // Default: list
+  return listPaths();
+}
+
+// ---------------------------------------------------------------------------
+// grove paths / grove path list
+// ---------------------------------------------------------------------------
+
+async function listPaths() {
+  const paths = await fetchPaths();
+  if (!paths) return;
+
+  const entries = Object.entries(paths);
+  if (entries.length === 0) {
+    console.log(`${pc.yellow("No paths configured.")}`);
+    return;
+  }
+
+  console.log(`${pc.bold("Paths")} (${entries.length})`);
+  console.log();
+
+  for (const [name, config] of entries) {
+    const builtIn = name in DEFAULT_PATHS ? pc.dim(" (built-in)") : "";
+    console.log(`  ${pc.green(name)}${builtIn}`);
+    console.log(`    ${pc.dim(config.description)}`);
+    console.log(`    ${pc.dim("steps:")} ${config.steps.map(s => s.id).join(" → ")}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// grove path show <name>
+// ---------------------------------------------------------------------------
+
+async function showPath(args: string[]) {
+  const name = args[0];
+  if (!name) {
+    console.log(`${pc.red("Usage:")} grove path show <name>`);
+    return;
+  }
+
+  const info = readBrokerInfo();
+  if (!info) {
+    console.log(`${pc.yellow("Grove is not running.")} Run ${pc.bold("grove up")} first.`);
+    return;
+  }
+
+  try {
+    const resp = await fetch(`${info.url}/api/paths/${encodeURIComponent(name)}`);
+    if (resp.status === 404) {
+      console.log(`${pc.red("Path not found:")} ${name}`);
+      return;
+    }
+    const data = await resp.json() as { name: string } & NormalizedPathConfig;
+
+    console.log(`${pc.bold(data.name)}`);
+    console.log(`${pc.dim(data.description)}`);
+    console.log();
+
+    for (const step of data.steps) {
+      const tag = step.type === "verdict"
+        ? pc.yellow(`[${step.type}]`)
+        : pc.cyan(`[${step.type}]`);
+      console.log(`  ${pc.green(step.id)} ${tag}`);
+
+      if (step.label && step.label !== step.id)
+        console.log(`    ${pc.dim("label:")} ${step.label}`);
+      if (step.prompt)
+        console.log(`    ${pc.dim("prompt:")} ${step.prompt.length > 80 ? step.prompt.slice(0, 80) + "…" : step.prompt}`);
+      if (step.skills?.length)
+        console.log(`    ${pc.dim("skills:")} ${step.skills.join(", ")}`);
+      if (step.sandbox !== "read-write")
+        console.log(`    ${pc.dim("sandbox:")} ${step.sandbox}`);
+      if (step.result_file)
+        console.log(`    ${pc.dim("result_file:")} ${step.result_file}`);
+      if (step.result_key)
+        console.log(`    ${pc.dim("result_key:")} ${step.result_key}`);
+      console.log(`    ${pc.dim("on_success:")} ${step.on_success}  ${pc.dim("on_failure:")} ${step.on_failure}`);
+      if (step.max_retries)
+        console.log(`    ${pc.dim("max_retries:")} ${step.max_retries}`);
+    }
+  } catch (err: any) {
+    console.log(`${pc.red("Error:")} ${err.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// grove path add <name> [--file <path>] [--description <desc>]
+// ---------------------------------------------------------------------------
+
+async function addPath(args: string[]) {
+  const info = readBrokerInfo();
+  if (!info) {
+    console.log(`${pc.yellow("Grove is not running.")} Run ${pc.bold("grove up")} first.`);
+    return;
+  }
+
+  // Parse --file flag
+  const fileIdx = args.indexOf("--file");
+  const filePath = fileIdx !== -1 ? args[fileIdx + 1] : undefined;
+
+  // Parse --description flag
+  const descIdx = args.indexOf("--description");
+  const description = descIdx !== -1 ? args[descIdx + 1] : undefined;
+
+  const name = args.find(a => !a.startsWith("--") && a !== filePath && a !== description);
+  if (!name) {
+    console.log(`${pc.red("Usage:")} grove path add <name> --file <path.json|path.yaml>`);
+    console.log(`       grove path add <name> --description "desc" (creates empty single-step path)`);
+    return;
+  }
+
+  let body: { name: string; description: string; steps: any[] };
+
+  if (filePath) {
+    // Import from file
+    const content = readFileSync(filePath, "utf-8");
+    const parsed = parsePathFile(content, filePath);
+    if (!parsed) return;
+    body = { name, description: parsed.description, steps: parsed.steps };
+  } else if (description) {
+    // Create minimal path with a single implement step
+    body = {
+      name,
+      description,
+      steps: [
+        { id: "implement", type: "worker", prompt: "Implement the task. Commit your changes with conventional commit messages." },
+      ],
+    };
+  } else {
+    console.log(`${pc.red("Usage:")} grove path add <name> --file <path.json|path.yaml>`);
+    console.log(`       grove path add <name> --description "desc" (creates single-step path)`);
+    return;
+  }
+
+  try {
+    const resp = await fetch(`${info.url}/api/paths`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    if (resp.status === 409) {
+      console.log(`${pc.red("✘")} Path ${pc.bold(`"${name}"`)} already exists.`);
+      return;
+    }
+    if (resp.status === 400) {
+      const data = await resp.json() as any;
+      console.log(`${pc.red("✘")} Validation failed:`);
+      for (const detail of data.details ?? [data.error]) {
+        console.log(`  - ${detail}`);
+      }
+      return;
+    }
+
+    const data = await resp.json() as NormalizedPathConfig;
+    console.log(`${pc.green("✓")} Path created: ${pc.bold(name)}`);
+    console.log(`  ${pc.dim(data.description)}`);
+    console.log(`  ${pc.dim("steps:")} ${data.steps.map(s => s.id).join(" → ")}`);
+  } catch (err: any) {
+    console.log(`${pc.red("Error:")} ${err.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// grove path remove <name> [--force]
+// ---------------------------------------------------------------------------
+
+async function removePath(args: string[]) {
+  const info = readBrokerInfo();
+  if (!info) {
+    console.log(`${pc.yellow("Grove is not running.")} Run ${pc.bold("grove up")} first.`);
+    return;
+  }
+
+  const name = args.find(a => !a.startsWith("--"));
+  if (!name) {
+    console.log(`${pc.red("Usage:")} grove path remove <name>`);
+    return;
+  }
+
+  try {
+    const resp = await fetch(`${info.url}/api/paths/${encodeURIComponent(name)}`, {
+      method: "DELETE",
+    });
+
+    if (resp.status === 404) {
+      console.log(`${pc.red("Path not found:")} ${name}`);
+      return;
+    }
+    if (resp.status === 403) {
+      const data = await resp.json() as any;
+      console.log(`${pc.red("✘")} ${data.error}`);
+      return;
+    }
+
+    console.log(`${pc.green("✓")} Removed path ${pc.bold(`"${name}"`)}`);
+  } catch (err: any) {
+    console.log(`${pc.red("Error:")} ${err.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// grove path export <name> [--json | --yaml]
+// ---------------------------------------------------------------------------
+
+async function exportPath(args: string[]) {
+  const info = readBrokerInfo();
+  if (!info) {
+    console.log(`${pc.yellow("Grove is not running.")} Run ${pc.bold("grove up")} first.`);
+    return;
+  }
+
+  const name = args.find(a => !a.startsWith("--"));
+  if (!name) {
+    console.log(`${pc.red("Usage:")} grove path export <name> [--json | --yaml] [--output <file>]`);
+    return;
+  }
+
+  const useJson = args.includes("--json");
+  const outputIdx = args.indexOf("--output");
+  const outputFile = outputIdx !== -1 ? args[outputIdx + 1] : undefined;
+
+  try {
+    const resp = await fetch(`${info.url}/api/paths/${encodeURIComponent(name)}`);
+    if (resp.status === 404) {
+      console.log(`${pc.red("Path not found:")} ${name}`);
+      return;
+    }
+
+    const data = await resp.json() as { name: string } & NormalizedPathConfig;
+    const exportData: PathConfig = {
+      description: data.description,
+      steps: data.steps.map(s => {
+        const step: Record<string, any> = { id: s.id, type: s.type };
+        if (s.prompt) step.prompt = s.prompt;
+        if (s.skills?.length) step.skills = s.skills;
+        if (s.sandbox !== "read-write") step.sandbox = s.sandbox;
+        if (s.result_file) step.result_file = s.result_file;
+        if (s.result_key) step.result_key = s.result_key;
+        if (s.on_success !== "$done") step.on_success = s.on_success;
+        if (s.on_failure !== "$fail") step.on_failure = s.on_failure;
+        if (s.max_retries) step.max_retries = s.max_retries;
+        return step;
+      }),
+    };
+
+    let output: string;
+    if (useJson) {
+      output = JSON.stringify(exportData, null, 2);
+    } else {
+      const { stringify } = await import("yaml");
+      output = stringify(exportData);
+    }
+
+    if (outputFile) {
+      writeFileSync(outputFile, output);
+      console.log(`${pc.green("✓")} Exported ${pc.bold(name)} to ${outputFile}`);
+    } else {
+      console.log(output);
+    }
+  } catch (err: any) {
+    console.log(`${pc.red("Error:")} ${err.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// grove path import <file> [--name <name>]
+// ---------------------------------------------------------------------------
+
+async function importPath(args: string[]) {
+  const info = readBrokerInfo();
+  if (!info) {
+    console.log(`${pc.yellow("Grove is not running.")} Run ${pc.bold("grove up")} first.`);
+    return;
+  }
+
+  const filePath = args.find(a => !a.startsWith("--"));
+  if (!filePath) {
+    console.log(`${pc.red("Usage:")} grove path import <file> [--name <name>]`);
+    return;
+  }
+
+  const nameIdx = args.indexOf("--name");
+  const nameOverride = nameIdx !== -1 ? args[nameIdx + 1] : undefined;
+
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf-8");
+  } catch {
+    console.log(`${pc.red("Cannot read file:")} ${filePath}`);
+    return;
+  }
+
+  const parsed = parsePathFile(content, filePath);
+  if (!parsed) return;
+
+  // Derive name from filename if not provided and not in file
+  const name = nameOverride
+    ?? parsed.name
+    ?? filePath.replace(/^.*[\\/]/, "").replace(/\.(json|ya?ml)$/i, "");
+
+  try {
+    const resp = await fetch(`${info.url}/api/paths`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, description: parsed.description, steps: parsed.steps }),
+    });
+
+    if (resp.status === 409) {
+      console.log(`${pc.red("✘")} Path ${pc.bold(`"${name}"`)} already exists.`);
+      return;
+    }
+    if (resp.status === 400) {
+      const data = await resp.json() as any;
+      console.log(`${pc.red("✘")} Validation failed:`);
+      for (const detail of data.details ?? [data.error]) {
+        console.log(`  - ${detail}`);
+      }
+      return;
+    }
+
+    const data = await resp.json() as NormalizedPathConfig;
+    console.log(`${pc.green("✓")} Imported path: ${pc.bold(name)}`);
+    console.log(`  ${pc.dim(data.description)}`);
+    console.log(`  ${pc.dim("steps:")} ${data.steps.map(s => s.id).join(" → ")}`);
+  } catch (err: any) {
+    console.log(`${pc.red("Error:")} ${err.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function fetchPaths(): Promise<Record<string, NormalizedPathConfig> | null> {
+  const info = readBrokerInfo();
+
+  if (info) {
+    try {
+      const resp = await fetch(`${info.url}/api/paths`);
+      return await resp.json() as Record<string, NormalizedPathConfig>;
+    } catch {
+      // Fall through to local config
+    }
+  }
+
+  // Broker not running — read local config
+  const { configNormalizedPathsForApi } = await import("../../broker/config");
+  return configNormalizedPathsForApi();
+}
+
+function parsePathFile(content: string, filePath: string): { name?: string; description: string; steps: any[] } | null {
+  let parsed: any;
+
+  if (filePath.endsWith(".json")) {
+    try {
+      parsed = JSON.parse(content);
+    } catch (err: any) {
+      console.log(`${pc.red("Invalid JSON:")} ${err.message}`);
+      return null;
+    }
+  } else {
+    // Assume YAML
+    try {
+      const { parse } = require("yaml");
+      parsed = parse(content);
+    } catch (err: any) {
+      console.log(`${pc.red("Invalid YAML:")} ${err.message}`);
+      return null;
+    }
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    console.log(`${pc.red("Invalid path definition:")} expected an object with description and steps`);
+    return null;
+  }
+
+  if (!parsed.description || !Array.isArray(parsed.steps)) {
+    console.log(`${pc.red("Invalid path definition:")} must have "description" (string) and "steps" (array)`);
+    return null;
+  }
+
+  return { name: parsed.name, description: parsed.description, steps: parsed.steps };
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,6 +21,8 @@ const commands: Record<string, () => Promise<{ run(args: string[]): Promise<void
   insights: () => import("./commands/insights"),
   cleanup:  () => import("./commands/cleanup"),
   plugins: () => import("./commands/plugins"),
+  paths: () => import("./commands/paths"),
+  path:  () => import("./commands/paths"),   // alias: grove path show
   skills: () => import("./commands/skills"),
   help:    () => import("./commands/help"),
   upgrade: () => import("./commands/upgrade"),
@@ -70,6 +72,7 @@ ${pc.bold("Commands:")}
   ${pc.green("config")}    Manage config (version, validate, migrate)
   ${pc.green("cost")}      Spend breakdown
   ${pc.green("insights")}  Cross-task pattern insights
+  ${pc.green("paths")}     Manage pipeline paths (CRUD)
   ${pc.green("plugins")}   Manage plugins
   ${pc.green("skills")}    Manage the skill library
   ${pc.green("help")}      Show this help

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -347,6 +347,11 @@ export interface EventBusMap {
   // Skill management events
   "skill:installed": { name: string };
   "skill:removed": { name: string };
+
+  // Path management events
+  "path:created": { name: string };
+  "path:updated": { name: string };
+  "path:deleted": { name: string };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds CLI commands and WebSocket event wiring for full pipeline path CRUD (W-069). The REST API endpoints (`GET/POST/PUT/DELETE /api/paths`) already existed in the broker; this PR adds the CLI interface and real-time event propagation.

### CLI Commands
- `grove paths` / `grove path list` — list all paths with step counts and built-in markers
- `grove path show <name>` — display full step definitions
- `grove path add <name> --file <path>` — create from JSON/YAML file
- `grove path add <name> --description "desc"` — create minimal single-step path
- `grove path remove <name>` — delete (respects built-in protection)
- `grove path export <name> [--json|--yaml] [--output <file>]` — export path definition
- `grove path import <file> [--name <name>]` — import path from JSON/YAML file

### WebSocket Events
- `path:created`, `path:updated`, `path:deleted` events emitted from REST mutation handlers
- Events forwarded to connected WebSocket clients for real-time GUI updates

### Files Changed
- `src/cli/commands/paths.ts` — new CLI command module
- `src/cli/index.ts` — command registration + help text
- `src/shared/types.ts` — EventBusMap path events
- `src/broker/server.ts` — event wiring + emission

## Test plan
- [ ] Run `grove paths` to list all paths
- [ ] Run `grove path show development` to view step details
- [ ] Run `grove path export development --json` to export a path
- [ ] Run `grove path add test-path --description "test"` to create a path
- [ ] Run `grove path remove test-path` to delete a path
- [ ] Verify WebSocket events fire when paths are mutated via API
- [ ] Verify GUI path editor still works

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)