### PR TITLE
feat: (W-070) add security-audit pipeline path and skill

### DIFF
--- a/.grove/session-summary.md
+++ b/.grove/session-summary.md
@@ -1,21 +1,26 @@
-# Session Summary: W-072
+# Session Summary: W-070
 
 ## Summary
 
-Resumed and verified the completed markdown table rendering feature. The previous session implemented proper HTML `<table>` rendering for markdown pipe tables in the `FormattedContent` component (`web/src/components/Chat.tsx`). This session confirmed the build passes cleanly (`tsc -b && vite build`) and the implementation is solid.
+Implemented the `security-audit` built-in pipeline path with four steps (scan → analyze → report → remediate) and a comprehensive security-audit skill. The path is now available as a default alongside development, research, and adversarial.
 
-### Key Design Decisions (from previous session)
+### Key Design Decisions
 
-- **Three block types**: `"text" | "box-table" | "md-table"` — first pass groups table-like lines, classification step separates box-drawing from valid markdown tables.
-- **No external dependencies**: Table parsing is self-contained (~50 lines).
-- **Graceful fallback**: Invalid pipe-table blocks fall back to `<pre>` rendering.
-- **Alignment support**: Parses GFM separator syntax (`:---`, `:---:`, `---:`) and applies via `textAlign` style.
-- **Inline formatting preserved**: Table cells pass through `InlineFormat` for `**bold**` and `` `code` `` rendering.
+- **Single skill, four steps**: One `security-audit` skill serves all pipeline steps, with step-specific sections. Matches the pattern used by other skills.
+- **Read-only analyze step**: The analysis/triage step runs in read-only sandbox — it reads scan results and classifies findings without modifying source files. On failure, it loops back to `scan`.
+- **Best-effort remediation**: The `remediate` step uses `on_failure: "$done"` — the pipeline succeeds even if auto-fixes fail, since the scan and report are the primary deliverables.
+- **Structured JSON interchange**: Each step produces a JSON file (`.grove/security-scan.json`, `.grove/security-analysis.json`, `.grove/security-remediation.json`) that downstream steps consume, plus a human-readable `.grove/security-report.md`.
+- **OWASP Top 10 coverage**: The skill includes a lookup table mapping each OWASP category to concrete patterns the worker should search for.
+- **False-positive heuristics**: The analyze step includes specific rules for common false positives (test fixtures, env var references, ORM parameterization, etc.).
 
 ## Files Modified
 
-- `web/src/components/Chat.tsx` — refactored `FormattedContent` block detection, added `parseMdTable` parser, `MarkdownTable` component, and supporting types/helpers
+- `src/shared/types.ts` — added `security-audit` to `DEFAULT_PATHS`
+- `grove.yaml.example` — updated built-in path list comment, added commented-out customization example
+- `skills/security-audit/skill.yaml` — new skill metadata
+- `skills/security-audit/skill.md` — comprehensive skill instructions for all 4 steps
+- `.grove/session-summary.md` — this file
 
 ## Next Steps
 
-- None — feature is complete. Build verified. Ready for merge.
+- None — feature is complete. Tests pass. Ready for commit.

--- a/grove.yaml.example
+++ b/grove.yaml.example
@@ -21,7 +21,7 @@ trees:
   #   branch_prefix: grove/
 
 # Paths: workflow templates that define the step pipeline per task type.
-# Built-in paths (development, research, content) are always available.
+# Built-in paths (development, research, adversarial, security-audit) are always available.
 # Add custom paths here:
 paths:
   # ops:
@@ -37,6 +37,21 @@ paths:
       - review:
           prompt: "Review this contributed PR. Check out the PR branch, read the diff, and write a structured review report to .grove/pr-review.md. Analyze for: backwards compatibility, test coverage, code quality, and adherence to project conventions. Include a clear verdict (Recommend Merge / Request Changes / Needs Discussion) and specific suggested comments per file."
       - verdict
+
+  # The security-audit path is built-in but can be customized here:
+  # security-audit:
+  #   description: Security audit — dependency scan, SAST, secrets detection, and report
+  #   steps:
+  #     - scan:
+  #         skills: [security-audit]
+  #     - analyze:
+  #         skills: [security-audit]
+  #         sandbox: read-only
+  #     - report:
+  #         skills: [security-audit]
+  #     - remediate:
+  #         skills: [security-audit]
+  #         on_failure: $done
 
 # Budget controls
 budgets:

--- a/skills/security-audit/skill.md
+++ b/skills/security-audit/skill.md
@@ -1,0 +1,291 @@
+---
+name: grove-security-audit
+description: Use when performing security audits on a codebase. Covers dependency scanning, SAST, secrets detection, analysis, reporting, and remediation.
+---
+
+You are performing a security audit of a codebase as part of a grove pipeline. This skill covers four pipeline steps: **scan**, **analyze**, **report**, and **remediate**. Follow the instructions for your current step.
+
+---
+
+## Step: scan
+
+Run a comprehensive security scan. Detect the project's language/package ecosystem and run the appropriate checks.
+
+### 1. Dependency Audit
+
+Detect the package manager and run the corresponding audit command:
+
+| Ecosystem | Detection File | Audit Command |
+|-----------|---------------|---------------|
+| Node.js | `package.json` | `npm audit --json` or `yarn audit --json` |
+| Python | `requirements.txt`, `pyproject.toml` | `pip-audit --format=json` or `safety check --json` |
+| Go | `go.mod` | `govulncheck ./...` |
+| Rust | `Cargo.toml` | `cargo audit --json` |
+| Ruby | `Gemfile` | `bundle audit check --format=json` |
+| Java/Kotlin | `pom.xml`, `build.gradle` | `mvn dependency-check:check` or `gradle dependencyCheckAnalyze` |
+
+If the tool isn't installed, note it as a finding with severity `info` and move on. Do not fail the scan because a tool is missing.
+
+### 2. Secrets Detection
+
+Search the codebase for hardcoded secrets using pattern matching. Check for:
+
+- **API keys**: patterns like `AKIA[0-9A-Z]{16}` (AWS), `sk-[a-zA-Z0-9]{48}` (OpenAI), `ghp_[a-zA-Z0-9]{36}` (GitHub PAT)
+- **Private keys**: `-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----`
+- **Connection strings**: `postgres://`, `mysql://`, `mongodb://`, `redis://` with embedded credentials
+- **Generic secrets**: variables named `password`, `secret`, `token`, `api_key`, `apikey`, `auth` assigned to string literals (not env vars or config lookups)
+- **JWT tokens**: `eyJ[A-Za-z0-9-_]+\.eyJ[A-Za-z0-9-_]+\.[A-Za-z0-9-_.+/=]*`
+- **High-entropy strings**: base64 or hex strings > 20 chars assigned to secret-looking variable names
+
+Exclude from secrets detection:
+- `.env.example`, `.env.sample` files (templates, not real secrets)
+- Test fixtures and mock data directories
+- Lock files (`package-lock.json`, `yarn.lock`, `Gemfile.lock`)
+- Files matching `.gitignore` patterns
+
+If `trufflehog` or `gitleaks` is available, run it as well and merge results.
+
+### 3. SAST — Static Analysis (OWASP Top 10)
+
+Scan source code for common vulnerability patterns:
+
+| OWASP Category | What to Look For |
+|----------------|-----------------|
+| **A01 Broken Access Control** | Missing auth checks on routes/endpoints, IDOR patterns (user ID from request used directly in DB query) |
+| **A02 Cryptographic Failures** | MD5/SHA1 for passwords, hardcoded salts, `Math.random()` for security, weak TLS configs |
+| **A03 Injection** | String concatenation in SQL/shell/LDAP queries, unsanitized template literals in queries, use of shell commands with string interpolation instead of parameterized execution |
+| **A04 Insecure Design** | Missing rate limiting, no CSRF tokens on state-changing endpoints, missing input validation |
+| **A05 Security Misconfiguration** | Debug mode enabled, default credentials, overly permissive CORS (`*`), directory listing enabled |
+| **A06 Vulnerable Components** | Flagged by dependency audit above |
+| **A07 Auth Failures** | Weak password requirements, missing account lockout, session tokens in URLs, cookies missing httpOnly/secure flags |
+| **A08 Data Integrity Failures** | Unsafe HTML injection (React dangerouslySetInnerHTML or equivalent), deserialization of untrusted data, missing integrity checks on downloads |
+| **A09 Logging Failures** | Passwords/tokens logged in plaintext, no logging on auth events, PII in logs |
+| **A10 SSRF** | User-controlled URLs passed to HTTP clients, DNS rebinding vectors |
+
+### Output Format
+
+Write findings to `.grove/security-scan.json`:
+
+```json
+{
+  "scan_complete": true,
+  "scanned_at": "2025-01-15T10:30:00Z",
+  "project_type": "node",
+  "tools_used": ["npm audit", "pattern matching"],
+  "tools_unavailable": ["trufflehog"],
+  "findings": [
+    {
+      "id": "SCAN-001",
+      "category": "dependency",
+      "severity": "high",
+      "title": "Prototype pollution in lodash",
+      "description": "lodash@4.17.15 has known prototype pollution vulnerability CVE-2020-8203",
+      "file": "package.json",
+      "line": null,
+      "evidence": "\"lodash\": \"^4.17.15\"",
+      "cve": "CVE-2020-8203",
+      "cwe": "CWE-1321"
+    },
+    {
+      "id": "SCAN-002",
+      "category": "secret",
+      "severity": "critical",
+      "title": "Hardcoded AWS access key",
+      "description": "AWS access key ID found in source code",
+      "file": "src/config.ts",
+      "line": 42,
+      "evidence": "const AWS_KEY = \"AKIA...\" (redacted)",
+      "cve": null,
+      "cwe": "CWE-798"
+    }
+  ],
+  "summary": {
+    "total": 2,
+    "critical": 1,
+    "high": 1,
+    "medium": 0,
+    "low": 0,
+    "info": 0
+  }
+}
+```
+
+---
+
+## Step: analyze
+
+Read `.grove/security-scan.json` and triage findings. You are read-only in this step — do not modify any source files.
+
+### Triage Process
+
+For each finding:
+
+1. **Verify it exists** — check the file and line number. If the code has changed or the finding is stale, mark it `false_positive`.
+2. **Check for false positives** using these heuristics:
+   - Secrets in test/mock files → `false_positive` (unless they look like real production secrets)
+   - Secrets that reference env vars or config lookups (e.g., `process.env.API_KEY`) → `false_positive`
+   - Dependency vulnerabilities that don't affect the used API surface → `low` (downgrade from original severity)
+   - SQL injection patterns in ORMs that auto-parameterize → `false_positive`
+   - Shell command patterns using parameterized execution (e.g., `execFile` with argument arrays) → `false_positive`
+3. **Cross-reference findings** — if a dependency vuln and a SAST finding point to the same root cause, link them.
+4. **Classify remediation effort**: `trivial` (version bump), `simple` (code change < 10 lines), `moderate` (refactor needed), `complex` (architectural change).
+
+### Output Format
+
+Write to `.grove/security-analysis.json`:
+
+```json
+{
+  "analysis_complete": true,
+  "analyzed_at": "2025-01-15T10:35:00Z",
+  "findings": [
+    {
+      "id": "SCAN-001",
+      "original_severity": "high",
+      "adjusted_severity": "high",
+      "status": "confirmed",
+      "false_positive": false,
+      "reason": "lodash prototype pollution is exploitable via merge/set functions which are used in src/utils.ts",
+      "remediation_effort": "trivial",
+      "suggested_fix": "Upgrade lodash to >=4.17.21",
+      "auto_fixable": true
+    },
+    {
+      "id": "SCAN-002",
+      "original_severity": "critical",
+      "adjusted_severity": "critical",
+      "status": "confirmed",
+      "false_positive": false,
+      "reason": "Real AWS access key in source code",
+      "remediation_effort": "simple",
+      "suggested_fix": "Move to environment variable, rotate the exposed key immediately",
+      "auto_fixable": false
+    }
+  ],
+  "summary": {
+    "total_scanned": 2,
+    "confirmed": 2,
+    "false_positives": 0,
+    "critical": 1,
+    "high": 1,
+    "medium": 0,
+    "low": 0,
+    "auto_fixable": 1
+  }
+}
+```
+
+---
+
+## Step: report
+
+Generate a human-readable security audit report from `.grove/security-analysis.json`.
+
+Write to `.grove/security-report.md` using this structure:
+
+```markdown
+# Security Audit Report
+
+**Project:** <project name>
+**Date:** <date>
+**Audited by:** Grove security-audit pipeline
+
+## Executive Summary
+
+<2-3 sentence overview: how many findings, what's the overall risk posture, are there any critical issues requiring immediate action?>
+
+## Risk Rating
+
+| Rating | Count |
+|--------|-------|
+| Critical | N |
+| High | N |
+| Medium | N |
+| Low | N |
+| Info | N |
+| False Positives | N |
+
+**Overall Risk:** <Critical / High / Medium / Low>
+
+## Critical & High Findings
+
+### [SCAN-XXX] <Title>
+
+- **Severity:** Critical
+- **Category:** <dependency / secret / sast>
+- **File:** `<path>:<line>`
+- **CWE:** <if applicable>
+- **Description:** <what was found>
+- **Impact:** <what could happen if exploited>
+- **Remediation:** <specific fix steps>
+- **Effort:** <trivial / simple / moderate / complex>
+
+<repeat for each critical/high finding>
+
+## Medium & Low Findings
+
+<table format for brevity>
+
+| ID | Severity | Category | File | Title | Fix |
+|----|----------|----------|------|-------|-----|
+| SCAN-XXX | Medium | sast | `file.ts:42` | Description | Suggested fix |
+
+## False Positives
+
+<brief list of dismissed findings with reasons, so the next auditor knows>
+
+## Recommendations
+
+1. **Immediate** — <actions for critical findings>
+2. **Short-term** — <actions for high findings>
+3. **Ongoing** — <process improvements, tooling suggestions>
+
+## Scan Metadata
+
+- Tools used: <list>
+- Tools unavailable: <list>
+- Files scanned: <count or scope>
+```
+
+---
+
+## Step: remediate
+
+Attempt automated fixes for findings marked `auto_fixable: true` in `.grove/security-analysis.json`. Only fix `trivial` and `simple` effort items.
+
+### Rules
+
+1. **Only fix low-risk items** — dependency upgrades, version pins, removing unused packages.
+2. **Never fix** — hardcoded secrets (requires key rotation outside the codebase), architectural issues, anything marked `moderate` or `complex` effort.
+3. **One commit per fix** — use conventional commit format: `fix: (security) upgrade lodash to 4.17.21 (CVE-2020-8203)`.
+4. **Verify after each fix** — run the project's test suite if available. If tests break, revert the fix and note it.
+5. **Update the report** — append a "Remediation Results" section to `.grove/security-report.md`.
+
+### Output Format
+
+Write to `.grove/security-remediation.json`:
+
+```json
+{
+  "remediation_complete": true,
+  "remediated_at": "2025-01-15T10:40:00Z",
+  "fixes_attempted": 1,
+  "fixes_applied": 1,
+  "fixes_failed": 0,
+  "fixes": [
+    {
+      "finding_id": "SCAN-001",
+      "action": "Upgraded lodash from 4.17.15 to 4.17.21",
+      "commit": "abc1234",
+      "tests_passed": true,
+      "reverted": false
+    }
+  ],
+  "skipped": [
+    {
+      "finding_id": "SCAN-002",
+      "reason": "Requires key rotation — cannot be auto-fixed"
+    }
+  ]
+}
+```

--- a/skills/security-audit/skill.yaml
+++ b/skills/security-audit/skill.yaml
@@ -1,0 +1,7 @@
+name: security-audit
+version: 1.0.0
+description: Security scanning, analysis, reporting, and automated remediation for codebases
+author: grove
+suggested_steps: [scan, analyze, report, remediate]
+files:
+  - skill.md

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -393,6 +393,24 @@ export const DEFAULT_PATHS: Record<string, PathConfig> = {
         result_file: ".grove/merge-result.json", result_key: "merged" },
     ],
   },
+  "security-audit": {
+    description: "Security audit — dependency scan, SAST, secrets detection, and report",
+    steps: [
+      { id: "scan", type: "worker", skills: ["security-audit"],
+        prompt: "Run a comprehensive security scan of this codebase. Check for dependency vulnerabilities, hardcoded secrets, and OWASP top-10 patterns. Write structured findings to `.grove/security-scan.json`.",
+        result_file: ".grove/security-scan.json", result_key: "scan_complete" },
+      { id: "analyze", type: "worker", skills: ["security-audit"], sandbox: "read-only",
+        prompt: "Triage the scan findings in `.grove/security-scan.json`. Cross-reference with known false-positive patterns, classify by severity (critical/high/medium/low/info), and write the triaged results to `.grove/security-analysis.json`.",
+        result_file: ".grove/security-analysis.json", result_key: "analysis_complete",
+        on_failure: "scan", max_retries: 2 },
+      { id: "report", type: "worker", skills: ["security-audit"],
+        prompt: "Generate a security audit report at `.grove/security-report.md` from the analysis in `.grove/security-analysis.json`. Include executive summary, critical findings, recommended remediations, and risk ratings." },
+      { id: "remediate", type: "worker", skills: ["security-audit"],
+        prompt: "Attempt automated fixes for low-risk findings from `.grove/security-analysis.json` — dependency upgrades, pinning versions, removing unused dependencies. Commit each fix separately. Skip anything that requires manual review. Write results to `.grove/security-remediation.json`.",
+        result_file: ".grove/security-remediation.json", result_key: "remediation_complete",
+        on_failure: "$done" },
+    ],
+  },
 };
 
 export const DEFAULT_BUDGETS: BudgetConfig = {


### PR DESCRIPTION
## Summary

Adds a built-in `security-audit` pipeline path with four steps: **scan → analyze → report → remediate**.

- **scan** (worker) — dependency audit, hardcoded secrets detection, OWASP top-10 pattern scanning
- **analyze** (worker, read-only) — triage findings by severity, cross-reference false-positive patterns, produce structured JSON
- **report** (worker) — generate `.grove/security-report.md` with executive summary, critical findings, remediations, risk ratings
- **remediate** (worker, optional) — attempt automated fixes for low-risk findings (dependency upgrades, etc.)

### Key design decisions

- Single `security-audit` skill serves all four steps with step-specific sections
- Read-only sandbox for the analyze step (loops back to scan on failure)
- Best-effort remediation (`on_failure: "$done"`) — pipeline succeeds even if auto-fixes fail
- Structured JSON interchange between steps (`.grove/security-scan.json`, `.grove/security-analysis.json`, etc.)
- OWASP Top 10 lookup table mapping categories to concrete search patterns
- False-positive heuristics for common patterns (test fixtures, env var refs, ORM parameterization)

### Files changed

- `src/shared/types.ts` — added `security-audit` to `DEFAULT_PATHS`
- `grove.yaml.example` — updated built-in path list, added customization example
- `skills/security-audit/skill.yaml` — new skill metadata
- `skills/security-audit/skill.md` — comprehensive skill instructions for all 4 steps

## Test plan

- [x] Existing tests pass
- [ ] Verify `security-audit` appears in default paths via CLI
- [ ] Run `security-audit` path against a sample project

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)