### PR TITLE
Create code-refactoring pipeline path (analysis, refactor, test, review)

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -141,10 +141,10 @@ paths:
 
 | Path | Steps | Description |
 |------|-------|-------------|
-| `development` | plan -> implement -> evaluate -> merge | Standard dev workflow with QA gate |
-| `research` | plan -> research -> report | Research task, no code changes |
-| `content` | plan -> implement -> evaluate -> publish | Documentation and content creation |
-| `adversarial` | plan -> review -> implement -> evaluate -> merge | Adversarial planning with review loop |
+| `development` | implement -> review -> merge | Standard dev workflow with review |
+| `research` | research -> report | Research task, no code changes |
+| `adversarial` | plan -> review-plan -> implement -> review-code -> merge | Adversarial planning with review loop |
+| `refactoring` | analyze -> plan -> implement -> verify -> review -> merge | Code refactoring with analysis and verification |
 
 See [Custom Paths](custom-paths.md) for the full guide on defining pipelines, step types, transitions, type inference, and retry behavior.
 

--- a/docs/guides/custom-paths.md
+++ b/docs/guides/custom-paths.md
@@ -1,6 +1,6 @@
 # Custom Paths
 
-Paths define the pipeline a task follows from creation to completion. Grove ships with built-in paths (`development`, `research`, `content`, and `adversarial`), and you can define custom ones in `grove.yaml`.
+Paths define the pipeline a task follows from creation to completion. Grove ships with built-in paths (`development`, `research`, `adversarial`, and `refactoring`), and you can define custom ones in `grove.yaml`.
 
 ---
 
@@ -190,6 +190,24 @@ plan ──▶ review ──▶ implement ──▶ evaluate ──▶ merge ─
 - **implement**: Worker implements the approved plan
 - **evaluate**: Gate runs tests, lint, diff size checks
 - **merge**: Push, PR, CI, auto-merge
+
+### `refactoring`
+
+For restructuring code without changing behavior:
+
+```
+analyze ──▶ plan ──▶ implement ──▶ verify ──▶ review ──▶ merge ──▶ $done
+                        ▲            │          │
+                        └── fail ────┘          │
+                        └── reject ─────────────┘
+```
+
+- **analyze**: Identify refactoring targets — code smells, duplication, complexity. Produces `.grove/refactor-analysis.json`.
+- **plan**: Create a refactoring plan with before/after descriptions, risk assessment, and test strategy. Writes `.grove/refactor-plan.md`.
+- **implement**: Execute the plan with atomic commits per logical change.
+- **verify**: Run tests, compare against pre-refactoring baseline, check complexity metrics improved.
+- **review**: Read-only adversarial review focused on accidental behavior changes and missing test coverage.
+- **merge**: Push, PR, CI, auto-merge.
 
 ---
 

--- a/grove.yaml.example
+++ b/grove.yaml.example
@@ -21,11 +21,7 @@ trees:
   #   branch_prefix: grove/
 
 # Paths: workflow templates that define the step pipeline per task type.
-<<<<<<< HEAD
-# Built-in paths (development, research, adversarial, security-audit) are always available.
-=======
-# Built-in paths (development, research, adversarial, refactoring) are always available.
->>>>>>> 81a94f7 (feat: (W-071) add refactoring pipeline path with analysis, verification, and review)
+# Built-in paths (development, research, adversarial, security-audit, refactoring) are always available.
 # Add custom paths here:
 paths:
   # ops:

--- a/grove.yaml.example
+++ b/grove.yaml.example
@@ -21,7 +21,11 @@ trees:
   #   branch_prefix: grove/
 
 # Paths: workflow templates that define the step pipeline per task type.
+<<<<<<< HEAD
 # Built-in paths (development, research, adversarial, security-audit) are always available.
+=======
+# Built-in paths (development, research, adversarial, refactoring) are always available.
+>>>>>>> 81a94f7 (feat: (W-071) add refactoring pipeline path with analysis, verification, and review)
 # Add custom paths here:
 paths:
   # ops:

--- a/skills/refactoring/skill.md
+++ b/skills/refactoring/skill.md
@@ -1,0 +1,141 @@
+---
+name: grove-refactoring
+description: Use during refactoring tasks — guides analysis of code smells, planning safe transformations, and verifying behavior preservation.
+---
+
+You are performing a code refactoring task. Your goal is to improve code structure without changing behavior.
+
+## Refactoring Principles
+
+1. **Behavior preservation is non-negotiable.** Every refactoring must produce identical observable behavior. If you're unsure, don't change it.
+2. **Atomic commits.** Each logical refactoring gets its own commit. Never mix multiple refactorings in one commit.
+3. **Tests first.** Before refactoring, ensure tests exist for the code you're changing. If they don't, write them first in a separate commit.
+4. **Measure improvement.** Track concrete metrics (file length, function count, duplication, nesting depth) before and after.
+
+## Code Smell Detection
+
+When analyzing code, look for these patterns:
+
+### High Priority
+- **Long functions** (>50 lines) — Extract into smaller, named functions
+- **Duplicated logic** — Find 3+ similar blocks and extract a shared abstraction
+- **Deep nesting** (>3 levels) — Use early returns, guard clauses, or extract helpers
+- **God objects/files** (>500 lines) — Split by responsibility into separate modules
+- **Feature envy** — A function that uses more of another module's data than its own
+
+### Medium Priority
+- **Long parameter lists** (>4 params) — Group into an options/config object
+- **Switch/if chains on type** — Replace with polymorphism or a dispatch map
+- **Primitive obsession** — Raw strings/numbers where a domain type would add clarity
+- **Dead code** — Unreachable branches, unused exports, commented-out blocks
+
+### Lower Priority
+- **Inconsistent naming** — Align with project conventions
+- **Magic numbers/strings** — Extract to named constants
+- **Temporal coupling** — Functions that must be called in a specific order
+
+## Analysis Output Format
+
+Write `.grove/refactor-analysis.json`:
+
+```json
+{
+  "summary": "Brief overview of findings",
+  "metrics": {
+    "files_analyzed": 42,
+    "total_issues": 12,
+    "by_severity": { "high": 3, "medium": 5, "low": 4 }
+  },
+  "targets": [
+    {
+      "file": "src/engine/processor.ts",
+      "line": 45,
+      "issue": "long-function",
+      "severity": "high",
+      "description": "processTask() is 120 lines with 4 levels of nesting",
+      "suggestion": "Extract validation, transformation, and persistence into separate functions"
+    }
+  ]
+}
+```
+
+## Refactoring Plan Format
+
+Write `.grove/refactor-plan.md` with this structure:
+
+```markdown
+# Refactoring Plan
+
+## Baseline Metrics
+- Files: X, Total lines: Y, Average function length: Z
+- Test coverage: N tests, all passing
+
+## Changes
+
+### 1. [Title] — [file(s)]
+- **Before:** Description of current state
+- **After:** Description of target state
+- **Risk:** Low/Medium/High — why
+- **Test strategy:** How to verify behavior is preserved
+
+### 2. ...
+
+## Execution Order
+Ordered list of changes, with dependencies noted.
+```
+
+## Safe Transformation Patterns
+
+### Extract Function
+1. Identify the code block to extract
+2. Determine inputs (parameters) and outputs (return value)
+3. Create the new function with a descriptive name
+4. Replace the original block with a call to the new function
+5. Run tests
+
+### Move to Module
+1. Identify code that belongs in a different module
+2. Create or identify the target module
+3. Move the code, updating imports in both source and all consumers
+4. Run tests
+
+### Replace Conditional with Polymorphism
+1. Identify repeated type-checking conditionals
+2. Define an interface for the shared behavior
+3. Create implementations for each type
+4. Replace conditionals with interface calls
+5. Run tests
+
+### Simplify Conditional
+1. Identify complex boolean expressions or deep nesting
+2. Extract conditions into named boolean variables
+3. Use early returns to reduce nesting
+4. Run tests
+
+## Verification Checklist
+
+After refactoring, verify:
+- [ ] All existing tests pass with no modifications
+- [ ] No public API signatures changed (unless intentional and documented)
+- [ ] No new dependencies introduced
+- [ ] File sizes decreased or stayed the same
+- [ ] Function lengths decreased
+- [ ] Nesting depth decreased
+- [ ] No commented-out code left behind
+
+Write verification results to `.grove/verify-result.json`:
+```json
+{
+  "tests_passed": true,
+  "baseline_comparison": "All 42 tests pass, matching pre-refactoring baseline",
+  "metrics_improved": true,
+  "details": {
+    "files_changed": 3,
+    "lines_before": 450,
+    "lines_after": 380,
+    "functions_extracted": 5,
+    "max_nesting_before": 5,
+    "max_nesting_after": 2
+  }
+}
+```

--- a/skills/refactoring/skill.yaml
+++ b/skills/refactoring/skill.yaml
@@ -1,0 +1,7 @@
+name: refactoring
+version: 1.0.0
+description: Code refactoring guidance — smell detection, complexity analysis, safe transformation patterns
+author: grove
+suggested_steps: [analyze, plan, implement]
+files:
+  - skill.md

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -393,7 +393,6 @@ export const DEFAULT_PATHS: Record<string, PathConfig> = {
         result_file: ".grove/merge-result.json", result_key: "merged" },
     ],
   },
-<<<<<<< HEAD
   "security-audit": {
     description: "Security audit — dependency scan, SAST, secrets detection, and report",
     steps: [
@@ -410,7 +409,8 @@ export const DEFAULT_PATHS: Record<string, PathConfig> = {
         prompt: "Attempt automated fixes for low-risk findings from `.grove/security-analysis.json` — dependency upgrades, pinning versions, removing unused dependencies. Commit each fix separately. Skip anything that requires manual review. Write results to `.grove/security-remediation.json`.",
         result_file: ".grove/security-remediation.json", result_key: "remediation_complete",
         on_failure: "$done" },
-=======
+    ],
+  },
   refactoring: {
     description: "Code refactoring with analysis, safe transformation, and verification",
     steps: [
@@ -429,7 +429,6 @@ export const DEFAULT_PATHS: Record<string, PathConfig> = {
       { id: "merge", type: "worker", skills: ["merge-handler"],
         prompt: "Push the branch, create a PR, wait for CI, and merge. Follow the merge-handler skill instructions exactly. Write your result to .grove/merge-result.json.",
         result_file: ".grove/merge-result.json", result_key: "merged" },
->>>>>>> 81a94f7 (feat: (W-071) add refactoring pipeline path with analysis, verification, and review)
     ],
   },
 };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -393,6 +393,7 @@ export const DEFAULT_PATHS: Record<string, PathConfig> = {
         result_file: ".grove/merge-result.json", result_key: "merged" },
     ],
   },
+<<<<<<< HEAD
   "security-audit": {
     description: "Security audit — dependency scan, SAST, secrets detection, and report",
     steps: [
@@ -409,6 +410,26 @@ export const DEFAULT_PATHS: Record<string, PathConfig> = {
         prompt: "Attempt automated fixes for low-risk findings from `.grove/security-analysis.json` — dependency upgrades, pinning versions, removing unused dependencies. Commit each fix separately. Skip anything that requires manual review. Write results to `.grove/security-remediation.json`.",
         result_file: ".grove/security-remediation.json", result_key: "remediation_complete",
         on_failure: "$done" },
+=======
+  refactoring: {
+    description: "Code refactoring with analysis, safe transformation, and verification",
+    steps: [
+      { id: "analyze", type: "worker", skills: ["refactoring"],
+        prompt: "Analyze the codebase for refactoring targets: code smells, duplicated logic, high cyclomatic complexity, large files. Write a structured analysis to `.grove/refactor-analysis.json` with fields: targets (array of {file, issue, severity, suggestion}), summary, and metrics." },
+      { id: "plan", type: "worker", skills: ["refactoring"],
+        prompt: "Based on the analysis in `.grove/refactor-analysis.json`, create a refactoring plan. For each change, describe: before/after, risk assessment, and test strategy. Write the plan to `.grove/refactor-plan.md`." },
+      { id: "implement", type: "worker", skills: ["refactoring"],
+        prompt: "Execute the refactoring plan from `.grove/refactor-plan.md`. Commit atomically per logical change. Preserve all existing behavior — no functional changes." },
+      { id: "verify", type: "worker",
+        prompt: "Run the full test suite. Compare results against pre-refactoring baseline. Verify: all tests pass, no behavior changes, complexity metrics improved. Write results to `.grove/verify-result.json` with fields: tests_passed (bool), baseline_comparison, metrics_improved (bool).",
+        result_file: ".grove/verify-result.json", result_key: "tests_passed", on_failure: "implement", max_retries: 2 },
+      { id: "review", type: "worker", skills: ["code-review"], sandbox: "read-only",
+        prompt: "Review the refactoring changes. Focus on: accidental behavior changes, missing test coverage for refactored paths, API surface changes, and whether complexity actually decreased. Write verdict to `.grove/review-result.json`.",
+        result_file: ".grove/review-result.json", result_key: "approved", on_failure: "implement", max_retries: 2 },
+      { id: "merge", type: "worker", skills: ["merge-handler"],
+        prompt: "Push the branch, create a PR, wait for CI, and merge. Follow the merge-handler skill instructions exactly. Write your result to .grove/merge-result.json.",
+        result_file: ".grove/merge-result.json", result_key: "merged" },
+>>>>>>> 81a94f7 (feat: (W-071) add refactoring pipeline path with analysis, verification, and review)
     ],
   },
 };

--- a/tests/engine/normalize-v3.test.ts
+++ b/tests/engine/normalize-v3.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { normalizePath } from "../../src/engine/normalize";
+import { DEFAULT_PATHS } from "../../src/shared/types";
 
 describe("v3 path normalization", () => {
   test("normalizes step with skills array", () => {
@@ -59,5 +60,59 @@ describe("v3 path normalization", () => {
       steps: [{ id: "evaluate", type: "gate" }],
     });
     expect(result.steps[0].type).toBe("worker");
+  });
+});
+
+describe("refactoring path normalization", () => {
+  test("DEFAULT_PATHS includes refactoring", () => {
+    expect(DEFAULT_PATHS.refactoring).toBeDefined();
+    expect(DEFAULT_PATHS.refactoring.description).toContain("refactoring");
+  });
+
+  test("refactoring path has all 6 steps", () => {
+    const result = normalizePath(DEFAULT_PATHS.refactoring);
+    expect(result.steps).toHaveLength(6);
+    const ids = result.steps.map(s => s.id);
+    expect(ids).toEqual(["analyze", "plan", "implement", "verify", "review", "merge"]);
+  });
+
+  test("analyze and plan steps inject refactoring skill", () => {
+    const result = normalizePath(DEFAULT_PATHS.refactoring);
+    expect(result.steps[0].skills).toEqual(["refactoring"]);
+    expect(result.steps[1].skills).toEqual(["refactoring"]);
+  });
+
+  test("verify step uses result_file for gate-like behavior", () => {
+    const result = normalizePath(DEFAULT_PATHS.refactoring);
+    const verify = result.steps.find(s => s.id === "verify")!;
+    expect(verify.result_file).toBe(".grove/verify-result.json");
+    expect(verify.result_key).toBe("tests_passed");
+    expect(verify.on_failure).toBe("implement");
+  });
+
+  test("review step is read-only and loops back to implement on failure", () => {
+    const result = normalizePath(DEFAULT_PATHS.refactoring);
+    const review = result.steps.find(s => s.id === "review")!;
+    expect(review.sandbox).toBe("read-only");
+    expect(review.on_failure).toBe("implement");
+    expect(review.skills).toEqual(["code-review"]);
+  });
+
+  test("step transitions chain correctly", () => {
+    const result = normalizePath(DEFAULT_PATHS.refactoring);
+    expect(result.steps[0].on_success).toBe("plan");       // analyze → plan
+    expect(result.steps[1].on_success).toBe("implement");   // plan → implement
+    expect(result.steps[2].on_success).toBe("verify");      // implement → verify
+    expect(result.steps[3].on_success).toBe("review");      // verify → review
+    expect(result.steps[4].on_success).toBe("merge");       // review → merge
+    expect(result.steps[5].on_success).toBe("$done");       // merge → done
+  });
+
+  test("merge step uses merge-handler skill", () => {
+    const result = normalizePath(DEFAULT_PATHS.refactoring);
+    const merge = result.steps.find(s => s.id === "merge")!;
+    expect(merge.skills).toEqual(["merge-handler"]);
+    expect(merge.result_file).toBe(".grove/merge-result.json");
+    expect(merge.result_key).toBe("merged");
   });
 });


### PR DESCRIPTION
## Summary

Add the `refactoring` built-in pipeline path — a 6-step workflow for code restructuring tasks that prioritizes behavior preservation over new functionality.

**Pipeline**: `analyze → plan → implement → verify → review → merge`

- **analyze** — Identify refactoring targets (code smells, duplication, complexity). Outputs `.grove/refactor-analysis.json`
- **plan** — Create refactoring plan with risk assessment and test strategy. Outputs `.grove/refactor-plan.md`
- **implement** — Execute refactoring with atomic commits per logical change
- **verify** — Run full test suite, confirm no behavior changes, check complexity improvement
- **review** — Adversarial review for accidental behavior changes, missing coverage, API surface changes
- **merge** — Standard merge step

### Key Design Decisions

- Two feedback loops: both `verify` and `review` loop back to `implement` on failure
- New `refactoring` skill injected into analyze, plan, and implement steps (code smell detection, safe transformation patterns, complexity measurement)
- `review` step reuses existing `code-review` skill

### Files Changed

- `src/shared/types.ts` — Added `refactoring` to `DEFAULT_PATHS`
- `skills/refactoring/skill.yaml` + `skill.md` — New refactoring skill
- `tests/engine/normalize-v3.test.ts` — 7 new tests for refactoring path normalization
- `grove.yaml.example` — Updated built-in paths comment
- `docs/guides/custom-paths.md` — Refactoring path documentation with pipeline diagram
- `docs/guides/configuration.md` — Updated built-in paths table

## Test plan

- [x] 663 tests pass, 0 failures
- [x] 7 new tests for refactoring path normalization
- [x] Existing normalize-v3 tests still pass (13 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes W-071