### PR TITLE
fix: stop duplicate entries in activity feed

### DIFF
--- a/web/src/hooks/useTasks.ts
+++ b/web/src/hooks/useTasks.ts
@@ -113,13 +113,12 @@ export function useTasks() {
         );
         break;
       case "worker:activity": {
+        // Only update the single-line status indicator — do NOT push to
+        // taskActivityLog here.  The typed agent:tool_use / agent:thinking /
+        // agent:text events (handled below) already append to the log, so
+        // appending here too caused every entry to appear twice.
         const tid = msg.data.taskId;
         taskActivity.set(tid, msg.data.msg);
-        if (!taskActivityLog.has(tid)) taskActivityLog.set(tid, []);
-        const log = taskActivityLog.get(tid)!;
-        log.push({ ts: Date.now(), msg: msg.data.msg });
-        if (log.length > MAX_LOG_ENTRIES) log.shift();
-        // Force re-render
         setTasks(prev => [...prev]);
         break;
       }


### PR DESCRIPTION
## Summary
- The activity feed was showing every event twice because `worker:activity` and `agent:tool_use`/`agent:thinking`/`agent:text` events both fire for the same action in `worker.ts`, and the client's `useTasks.ts` was appending to the activity log from both handlers
- Fix: stop pushing to `taskActivityLog` from the `worker:activity` handler — the typed `agent:*` handlers already cover it with richer `kind` tags (tool, thinking, text, cost)
- `worker:activity` still updates the single-line `taskActivity` status indicator in the task list sidebar

## Test plan
- [ ] Open a task detail with an active worker — verify each event appears once, not twice
- [ ] Verify the task list sidebar still shows the latest activity one-liner
- [ ] Verify completed task activity logs show correct (non-duplicated) history

🤖 Generated with [Claude Code](https://claude.com/claude-code)