### PR TITLE
commit: fix for tree removal issue when task is added

### DIFF
--- a/src/broker/schema-sql.ts
+++ b/src/broker/schema-sql.ts
@@ -16,8 +16,8 @@ CREATE TABLE IF NOT EXISTS trees (
 
 CREATE TABLE IF NOT EXISTS tasks (
   id TEXT PRIMARY KEY,
-  tree_id TEXT REFERENCES trees(id),
-  parent_task_id TEXT REFERENCES tasks(id),
+  tree_id TEXT REFERENCES trees(id) ON DELETE CASCADE,
+  parent_task_id TEXT REFERENCES tasks(id) ON DELETE CASCADE,
   title TEXT NOT NULL,
   description TEXT,
   status TEXT NOT NULL DEFAULT 'draft',
@@ -49,8 +49,8 @@ CREATE TABLE IF NOT EXISTS tasks (
 );
 
 CREATE TABLE IF NOT EXISTS task_edges (
-  from_task TEXT NOT NULL REFERENCES tasks(id),
-  to_task TEXT NOT NULL REFERENCES tasks(id),
+  from_task TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  to_task TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
   edge_type TEXT NOT NULL DEFAULT 'dependency',
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   PRIMARY KEY (from_task, to_task)
@@ -59,7 +59,7 @@ CREATE INDEX IF NOT EXISTS idx_task_edges_to ON task_edges(to_task);
 
 CREATE TABLE IF NOT EXISTS sessions (
   id TEXT PRIMARY KEY,
-  task_id TEXT REFERENCES tasks(id),
+  task_id TEXT REFERENCES tasks(id) ON DELETE CASCADE,
   role TEXT NOT NULL,
   pid INTEGER,
   tmux_pane TEXT,

--- a/src/broker/schema.sql
+++ b/src/broker/schema.sql
@@ -18,8 +18,8 @@ CREATE TABLE IF NOT EXISTS trees (
 -- Tasks: work items
 CREATE TABLE IF NOT EXISTS tasks (
   id TEXT PRIMARY KEY,
-  tree_id TEXT REFERENCES trees(id),
-  parent_task_id TEXT REFERENCES tasks(id),
+  tree_id TEXT REFERENCES trees(id) ON DELETE CASCADE,
+  parent_task_id TEXT REFERENCES tasks(id) ON DELETE CASCADE,
   title TEXT NOT NULL,
   description TEXT,
   status TEXT NOT NULL DEFAULT 'draft',
@@ -51,7 +51,7 @@ CREATE TABLE IF NOT EXISTS tasks (
 -- Sessions: one per agent spawn (orchestrator, worker, evaluator)
 CREATE TABLE IF NOT EXISTS sessions (
   id TEXT PRIMARY KEY,
-  task_id TEXT REFERENCES tasks(id),
+  task_id TEXT REFERENCES tasks(id) ON DELETE CASCADE,
   role TEXT NOT NULL,
   pid INTEGER,
   tmux_pane TEXT,
@@ -86,7 +86,7 @@ CREATE TABLE IF NOT EXISTS messages (
 -- Seeds: brainstorming design artifacts attached to tasks
 CREATE TABLE IF NOT EXISTS seeds (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  task_id TEXT NOT NULL UNIQUE REFERENCES tasks(id),
+  task_id TEXT NOT NULL UNIQUE REFERENCES tasks(id) ON DELETE CASCADE,
   summary TEXT,
   spec TEXT,
   conversation TEXT,


### PR DESCRIPTION
**Summary:**
Added ON DELETE CASCADE to foreign key constraints in database schema to properly handle cascading deletes when trees or tasks are removed.

**Changes:**
- Added ON DELETE CASCADE to tree_id and parent_task_id references in tasks table
- Added ON DELETE CASCADE to from_task and to_task references in task_edges table
- Added ON DELETE CASCADE to task_id reference in sessions table
- Added ON DELETE CASCADE to task_id reference in seeds table
 
**Files modified:**
- src/broker/schema-sql.ts (+10/-5 lines)
- src/broker/schema.sql (+8/-4 lines)

**Fixes For**
- #190 